### PR TITLE
[디자인] 비밀번호 변경 페이지 수정 및 유저 페이지 일부 수정

### DIFF
--- a/site/judge/views/user.py
+++ b/site/judge/views/user.py
@@ -148,7 +148,7 @@ class CustomLoginView(LoginView):
 
 class CustomPasswordChangeView(PasswordChangeView):
     template_name = 'registration/password_change_form.html'
-    
+
     def form_valid(self, form):
         self.request.session['password_pwned'] = False
         return super().form_valid(form)

--- a/site/judge/views/user.py
+++ b/site/judge/views/user.py
@@ -148,7 +148,7 @@ class CustomLoginView(LoginView):
 
 class CustomPasswordChangeView(PasswordChangeView):
     template_name = 'registration/password_change_form.html'
-
+    
     def form_valid(self, form):
         self.request.session['password_pwned'] = False
         return super().form_valid(form)

--- a/site/templates/blog/list.html
+++ b/site/templates/blog/list.html
@@ -39,6 +39,7 @@
 
 {% block body %}
     {% block before_posts %}{% endblock %}
+    <!-- mobile div는 현재 숨겨져 있음. 기능은 잘 모르겠다. -->
     <div id="mobile" class="tabs">
         <ul>
             <li id="blog-tab" class="tab active"><a href="#">
@@ -47,6 +48,7 @@
             <li id="event-tab" class="tab"><a href="#"><i class="tab-icon fa fa-rss"></i> {{ _('Events') }}</a></li>
         </ul>
     </div>
+    <!-- 메인 페이지의 내용 부분. -->
     <div id="blog-container">
         <div class="blog-content sidebox">
             <h3>{{ _('News') }} <i class="fa fa-terminal"></i></h3>

--- a/site/templates/registration/password_change_form.html
+++ b/site/templates/registration/password_change_form.html
@@ -1,7 +1,136 @@
 {% extends "base.html" %}
 
+{% block media %}
+    <style>
+        .centered-form {
+            width: 62.5%;
+            margin: 50px auto;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            text-align: center;
+            max-width: none;
+        }
+        .centered-form h2 {
+            margin-bottom: 20px;
+            font-size: 24px;
+        }
+        .form-area {
+            width: 45%;
+            margin: 0 auto;
+            border: none;
+            background: none;
+        }
+        .form-area .password-rule {
+            border-radius: 8px;
+            border: 1px solid #5C95D9;
+            text-align: left;
+            margin-bottom: 10px;
+            cursor: pointer;
+            /* margin-left: 10px; */
+        }
+        .form-area .password-rule p {
+            font-size: 15px;
+            font-weight: bold;
+            text-align: center;
+            padding-left: 10px;
+            color: #5C95D9;
+            margin: 0;
+            height: 40px;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+        }
+        .form-area .password-rule p:hover {
+            color: #5C95D9;
+        }
+        .form-area .password-rule ul {
+            margin-block-start: 5px;
+            margin-block-end: 5px;
+            padding-inline-start: 20px;
+            display: none;
+            list-style: circle;
+            margin-bottom: 10px;
+        }
+        .form-area .password-rule ul li {
+            font-size: 14px;
+            margin-top: 5px;
+        }
+        .centered-form .form-area .django-as-table {
+            width: 100%;
+        }
+        .centered-form .form-area .django-as-table tr th {
+            display: none;
+        }
+        .centered-form .form-area .django-as-table tr td input {
+            width: 100%;
+            height: 48px;
+            margin-bottom: 10px;
+            border-radius: 8px;
+            border: 1px solid #ddd;
+            font-size: 16px;
+        }
+        .centered-form .form-area .django-as-table tr td input[name="old_password"] {
+        }
+        .centered-form .form-area .django-as-table tr td input[name="new_password1"] {
+        }
+        .centered-form .form-area .django-as-table tr td input[name="new_password2"] {
+        }
+        .centered-form .form-area .django-as-table .helptext {
+        }
+        .centered-form .form-area .django-as-table .helptext ul {
+            padding-inline-start: 10px;
+            border: 1px solid #ddd;
+            list-style: circle;
+            display: none;
+        }
+        .centered-form .form-area .submit-bar {
+            width: 100%;
+            background: none;
+            background-color: #5C95D9;
+            border-radius: 8px;
+            border: 1px solid #5C95D9;
+            height: 40px;
+            font-size: 14px;
+            margin-top: 10px;
+        }
+    </style>
+{% endblock %}
+
+{% block js_media %}
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            var oldPasswordInput = document.querySelector('input[name="old_password"]');
+            var newPassword1Input = document.querySelector('input[name="new_password1"]');
+            var newPassword2Input = document.querySelector('input[name="new_password2"]');
+
+            if (oldPasswordInput) {
+                oldPasswordInput.placeholder = "{{ _('기존 비밀번호') }}";
+            }
+            if (newPassword1Input) {
+                newPassword1Input.placeholder = "{{ _('새 비밀번호') }}";
+            }
+            if (newPassword2Input) {
+                newPassword2Input.placeholder = "{{ _('새 비밀번호 다시 입력') }}";
+            }
+
+            var passwordRule = document.querySelector('.password-rule');
+            var passwordRuleList = passwordRule.querySelector('ul');
+
+            passwordRule.addEventListener('click', function() {
+                if (passwordRuleList.style.display === "none" || passwordRuleList.style.display === "") {
+                    passwordRuleList.style.display = "block";
+                } else {
+                    passwordRuleList.style.display = "none";
+                }
+            });
+        });
+    </script>
+{% endblock %}
+
 {% block body %}
     <div class="centered-form">
+        <h2>비밀번호 변경</h2>
         <form action="" method="post" class="form-area">
             {% if request.session.password_pwned %}
                 <h4>{{ (_('We found your password in [a database of compromised passwords][0].') + '\n\n  [0]: https://haveibeenpwned.com/Passwords')|markdown('default', strip_paragraphs=True) }}
@@ -9,7 +138,15 @@
             {% endif %}
             {% csrf_token %}
             <table border="0" class="django-as-table">{{ form.as_table() }}</table>
-            <hr>
+            <div class="password-rule">
+                <p>비밀번호 생성 규칙</p>
+                <ul>
+                    <li>비밀번호는 최소 8자 이상이어야 합니다.</li>
+                    <li>다른 개인 정보와 유사한 비밀번호는 사용할 수 없습니다.</li>
+                    <li>너무 흔한 비밀번호는 비밀번호로 사용할 수 없습니다.</li>
+                    <li>숫자로만 이루어진 비밀번호는 사용할 수 없습니다.</li>
+                </ul>
+            </div>
             <button class="submit-bar" type="submit">{{ _('Change Password') }}</button>
         </form>
     </div>

--- a/site/templates/user/base-users.html
+++ b/site/templates/user/base-users.html
@@ -126,9 +126,13 @@
             flex-direction: row;
             justify-content: center;
         }
+        .bottom-pagination-bar .pagination {
+            color: #8391A1;
+        }
         ul.pagination > li > a, ul.pagination > li > span {
             background: none;
             border: none;
+            color: #8391A1;
         }
         ul.pagination > .active-page > a, ul.pagination > .active-page > span {
             background: none;


### PR DESCRIPTION
- 비밀번호 변경 페이지를 수정했습니다.
- 비밀번호 생성 규칙을 누르면 나타나도록 수정했는데, 논의 후 변경이 필요하면 변경하도록 하겠습니다.

![image](https://github.com/alps-jbnu/JBNU-Litmus/assets/113423804/0866c42e-2d74-467a-acbb-82d0246afc4f)
![image](https://github.com/alps-jbnu/JBNU-Litmus/assets/113423804/50b53cbc-ec7e-4345-a0d6-aeb0ec81e4e3)


- 유저 페이지에서 pagination-bar 색상을 변경했습니다.
![image](https://github.com/alps-jbnu/JBNU-Litmus/assets/113423804/567cea10-5af6-418f-99c6-38d62f02e06c)
 - 유저 페이지 pagination-bar의 기능 수정이 필요합니다. 제가 추후에 변경하겠습니다.
 - 유저 리스트가 하나인 경우 오른쪽 버튼이 보이지 않도록 수정 필요
 - 마지막 유저 리스트에서 오른쪽 버튼이 보이지 않도록 수정 필요
 - 마지막 유저 리스트에서 왼쪽 버튼이 클릭되지 않는 문제 수정 필요