### PR TITLE
Jeong gu/feature fix admin filter

### DIFF
--- a/site/judge/admin/comments.py
+++ b/site/judge/admin/comments.py
@@ -45,7 +45,8 @@ class CombinedCommnetFilter(FieldListFilter):
         is_public = request.GET.get('is_public')
         
         if is_public in ['True', 'False']:
-            queryset = queryset.filter(is_public=(is_public == 'True'))
+            # Comment uses `hidden`; public means hidden=False.
+            queryset = queryset.filter(hidden=(is_public == 'False'))
             
         return queryset
 

--- a/site/judge/admin/submission.py
+++ b/site/judge/admin/submission.py
@@ -138,7 +138,7 @@ class CombinedSubmissionFilter(FieldListFilter):
             queryset = queryset.filter(problem__name__icontains=problem_name)
 
         if username:
-            queryset = queryset.filter(user__username__icontains=username)
+            queryset = queryset.filter(user__user__username__icontains=username)
 
         return queryset
 


### PR DESCRIPTION
# 관리자 페이지 제출 탭의 사용자 이름 필터링이 안되는 문제 수정

## What
- CombinedSubmissionFilter의 username에 대한 queryset이 Profile DB를 가르키는데 user DB를 가르키고 있었던 문제
## How
- ProfileDB를 참조하는 것으로 수정해 해결 
<img width="860" height="80" alt="image" src="https://github.com/user-attachments/assets/41580332-22a7-48af-b1a2-4e2cd2ea7f27" />

# 관리자 페이지 댓글 탭의 공개 여부 필터링이 안되는 문제 수정

## What
- Comment 필드가 hidden을 사용하고 있는데, 필터에서 is_public 으로 매핑하려고 했던 문제
## How
- 필터 조건을 hidden으로 수정
<img width="687" height="61" alt="image" src="https://github.com/user-attachments/assets/a1c2e762-fab3-4dbf-a79d-c1f466061a0f" />
