### PR TITLE
Lia0519/feature logo edit

### DIFF
--- a/site/resources/dark/style.css
+++ b/site/resources/dark/style.css
@@ -371,7 +371,7 @@ nav {
 }
 nav ul {
   margin: 0 0 0 -5px;
-  padding: 0 0 0 1%;
+  padding: 0;
   display: block;
 }
 nav ul li {

--- a/site/resources/style.css
+++ b/site/resources/style.css
@@ -371,7 +371,7 @@ nav {
 }
 nav ul {
   margin: 0 0 0 -5px;
-  padding: 0 0 0 1%;
+  padding: 0;
   display: block;
 }
 nav ul li {

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -452,7 +452,7 @@
         }
         nav ul {
             margin: 0 0 0 -5px;
-            padding: 0 0 0 1%;
+            padding: 0;
             display: block;
         }
         nav ul li {

--- a/site/templates/organization/base.html
+++ b/site/templates/organization/base.html
@@ -216,6 +216,13 @@
         margin: 0 auto;
         box-shadow: 0px 7px 29px 0px rgba(100, 100, 111, 0.1);
         }
+
+        #nav-container .litmus_logo {
+        height: 44px;
+        width: auto;
+        display: block;
+        }
+        
         #nav-list {
             width: 75%;
             margin: 0 auto;
@@ -231,7 +238,7 @@
         }
         nav ul {
             margin: 0 0 0 -5px;
-            padding: 0 0 0 1%;
+            padding: 0;
             display: block;
         }
         nav ul li {


### PR DESCRIPTION
문제 상세 페이지에서 문제의 본문 글씨와 리트머스 로고가 맞지 않는 문제

## WHAT
<img width="862" height="404" alt="image" src="https://github.com/user-attachments/assets/96973282-4162-46c1-a93b-d1eb0c70dbaa" />
문제 상세 페이지에서 문제의 본문 글씨와 리트머스 로고가 맞지 않는 문제

## HOW
리트머스 로고의 .png와 .svg 모두 앞부분을 잘라 해결
<img width="1184" height="578" alt="image" src="https://github.com/user-attachments/assets/74b31e7d-a9a6-4dc9-a4b0-e8b656458224" />

# 문제 발생
-> 하지만 화면 크기를 150% 이상으로 커질경우, 깨짐 문제 발생