### PR TITLE
fix: 댓글 기능 비활성화

### DIFF
--- a/site/judge/admin/__init__.py
+++ b/site/judge/admin/__init__.py
@@ -26,7 +26,7 @@ from judge.models import BlogPost, Comment, CommentLock, Contest, ContestPartici
     PatchNote
 
 # admin.site.register(BlogPost, BlogPostAdmin)``
-admin.site.register(Comment, CommentAdmin)
+# admin.site.register(Comment, CommentAdmin) # 260112 댓글 기능 비활성화
 # admin.site.register(CommentLock)
 admin.site.register(Contest, ContestAdmin)
 admin.site.register(ContestParticipation, ContestParticipationAdmin)

--- a/site/templates/comments/list.html
+++ b/site/templates/comments/list.html
@@ -116,7 +116,7 @@
         margin: 8px 0;
     }
     .vote {
-        padding-top: 0 !important;
+        padding-top: 0;
     }
     .info {
         padding-bottom: 0.5em;


### PR DESCRIPTION
# 유저/관리자 댓글 기능 비활성화  

## What
- 현재까지 DB에 저장되어있는 Comment들을 확인해보니 문제 공지사항과 관련된 부분이 많아 기능이 겹치는 문제 발생
- 기능을 활용할 방법이 따로 없다고 판단

## How
``` #comments { display : none; } ```
``` # admin.site.register(Comment, CommentAdmin) # 260112 댓글 기능 비활성화 ```
- 문제 페이지에서 댓글 display를 none으로 해결
- 관리자 페이지 메뉴 목록에서 comment 기능 주석처리로 해결   