### PR TITLE
fix: Java 8 컴파일 에러시 사형선고 문구 수정

### DIFF
--- a/site/templates/submission/status-testcases.html
+++ b/site/templates/submission/status-testcases.html
@@ -295,7 +295,7 @@ function confirm_rejudge() {
                     <h3 class="card-title">{{ _('Compilation Error') }}</h3>
                 </div>
                 <div class="card-content">
-                    <div class="warning-text">{{ submission.error|ansi2html }}</div>
+                    <div class="warning-text">{{ submission.error|replace('You are a troll. Trolls are not welcome. As a judge, I sentence your code to death.', '컴파일 에러: 컴파일러 진단 메시지를 수신하지 못했습니다.')|ansi2html }}</div>
                 </div>
             </div>
         {% else %}


### PR DESCRIPTION
### What
<img width="1347" height="184" alt="스크린샷 2026-01-12 160044" src="https://github.com/user-attachments/assets/8d9d6ea6-d114-406d-9876-ff57f5ad82cd" />
- Java8 컴파일 시 특수한 케이스에 한해 해당 문구 (불친절한 문구) 가 띄워지는 문제

### How
- 컴파일 에러시 문제를 좀 더 명확하게 설명해주는 식으로 바꾸려 했으나 시스템 상 에러코드를 특정할 수 없음을 확인
- 또한 수정을 위해서는 DMOJ 내부의 Java 채점기 수정 필요
- 따라서 페이지 렌더링 시 해당 문구가 떴을 경우 '컴파일 에러: 제출한 코드가 리트머스 서버에서 지원하는 제출 코드 형식에 해당하지 않아 컴파일할 수 없습니다.' 라는 문구가 뜨도록 수정
``` {{ submission.error|replace('You are a troll. Trolls are not welcome. As a judge, I sentence your code to death.','컴파일 에러: 제출한 코드가 리트머스 서버에서 지원하는 제출 코드 형식에 해당하지 않아 컴파일할 수 없습니다.')|ansi2html }} ```
<img width="1367" height="247" alt="image" src="https://github.com/user-attachments/assets/29be736c-cd57-4ba5-b61c-ab53ac2a612d" />

