### PR TITLE
Hcw889/feature java8 troll message

### DIFF
--- a/site/templates/submission/status-testcases.html
+++ b/site/templates/submission/status-testcases.html
@@ -295,7 +295,7 @@ function confirm_rejudge() {
                     <h3 class="card-title">{{ _('Compilation Error') }}</h3>
                 </div>
                 <div class="card-content">
-                    <div class="warning-text">{{ submission.error|ansi2html }}</div>
+                    <div class="warning-text">{{ submission.error|replace('You are a troll. Trolls are not welcome. As a judge, I sentence your code to death.', '컴파일 에러: 컴파일러 진단 메시지를 수신하지 못했습니다.')|ansi2html }}</div>
                 </div>
             </div>
         {% else %}

--- a/site/templates/submission/status-testcases.html
+++ b/site/templates/submission/status-testcases.html
@@ -295,7 +295,7 @@ function confirm_rejudge() {
                     <h3 class="card-title">{{ _('Compilation Error') }}</h3>
                 </div>
                 <div class="card-content">
-                    <div class="warning-text">{{ submission.error|replace('You are a troll. Trolls are not welcome. As a judge, I sentence your code to death.', '컴파일 에러: 컴파일러 진단 메시지를 수신하지 못했습니다.')|ansi2html }}</div>
+                    <div class="warning-text">{{ submission.error|replace('You are a troll. Trolls are not welcome. As a judge, I sentence your code to death.','컴파일 에러: 제출한 코드가 리트머스 서버에서 지원하는 제출 코드 형식에 해당하지 않아 컴파일할 수 없습니다.')|ansi2html }}</div>
                 </div>
             </div>
         {% else %}


### PR DESCRIPTION
### What
<img width="1919" height="608" alt="스크린샷 2026-01-12 161937" src="https://github.com/user-attachments/assets/b5f4d208-cb0f-4278-8810-ba23bc2f1bc6" />
- Java8 컴파일 시 특수한 케이스에 한해 해당 문구 (불친절한 문구) 가 띄워지는 문제

### How
- 컴파일 에러시 문제를 좀 더 명확하게 설명해주는 식으로 바꾸려 했으나 시스템 상 에러코드를 특정할 수 없음을 확인
- 또한 해결을 위해서는 DMOJ 내부의 Java 채점기 수정 필요
- 따라서 페이지 렌더링 시 해당 문구가 떴을 경우 '컴파일 에러: 제출한 코드가 리트머스 서버에서 지원하는 제출 코드 형식에 해당하지 않아 컴파일할 수 없습니다.' 라는 문구가 뜨도록 수정
``` <div class="warning-text">{{ submission.error|replace('You are a troll. Trolls are not welcome. As a judge, I sentence your code to death.','컴파일 에러: 제출한 코드가 리트머스 서버에서 지원하는 제출 코드 형식에 해당하지 않아 컴파일할 수 없습니다.')|ansi2html }}</div> ```
<img width="1371" height="233" alt="스크린샷 2026-01-13 002159" src="https://github.com/user-attachments/assets/ebfef288-094b-48cc-bbe2-14efaa81bb07" />
