### PR TITLE
fix: 프로파일 탭에 있는 구버전 필터 삭제 + 필터 적용 버튼 위치 조정

### DIFF
--- a/site/judge/admin/profile.py
+++ b/site/judge/admin/profile.py
@@ -180,12 +180,9 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
                     'date_joined_display', 'last_access_display', 'ip', 'show_public')
     ordering = ('user__username',)
     search_fields = ('user__username', 'ip', 'user__email')
+    # 커스텀 필터만 사용 - Django 기본 필터들 제거
     list_filter = [
         ('id', CombinedProfileFilter),
-        'user__is_staff',
-        'user__is_superuser', 
-        'user__is_active',
-        'user__groups',
     ]
     actions = ('recalculate_points',)
     actions_on_top = True

--- a/site/judge/admin/users.py
+++ b/site/judge/admin/users.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from judge.models import Profile
 
 class Users(AbstractUser):
-    
+
     class Meta(AbstractUser.Meta):
         swappable = 'AUTH_USER_MODEL'
 
@@ -19,19 +19,21 @@ class UserCombinedInputFilter(FieldListFilter):
         super().__init__(field, request, params, model, model_admin, field_path)
         self.request = request
         self.params = params
-        
-        # 그룹 목록 가져오기
+
+        # 그룹 목록 가져오기 (필터 폼에서만 사용)
         self.__group_lookups = tuple(Group.objects.values_list('id', 'name'))
         self.__group_handles = set(str(group_id) for group_id, _ in self.__group_lookups)
-        
-        self.filter_keys = ['username', 'email', 'first_name', 'is_active', 'is_staff', 'is_superuser', 'groups']
+
+        # 커스텀 필터 폼에서 사용하는 필드들만 포함
+        self.filter_keys = ['username', 'email', 'first_name']
 
     @property
     def group_lookups(self):
         return self.__group_lookups
 
     def expected_parameters(self):
-        return ['username', 'email', 'first_name', 'is_active', 'is_staff', 'is_superuser', 'groups']
+        # 커스텀 필터 폼에서 사용하는 파라미터들만
+        return ['username', 'email', 'first_name']
 
     def choices(self, changelist):
         yield {
@@ -44,45 +46,29 @@ class UserCombinedInputFilter(FieldListFilter):
         username = request.GET.get('username')
         email = request.GET.get('email')
         first_name = request.GET.get('first_name')
-        is_active = request.GET.get('is_active')
-        is_staff = request.GET.get('is_staff')
-        is_superuser = request.GET.get('is_superuser')
-        groups = request.GET.get('groups')
 
         if username:
             queryset = queryset.filter(username__icontains=username)
-        
+
         if email:
             queryset = queryset.filter(email__icontains=email)
-            
+
         if first_name:
             queryset = queryset.filter(first_name__icontains=first_name)
 
-        if is_active in ['True', 'False']:
-            queryset = queryset.filter(is_active=(is_active == 'True'))
-            
-        if is_staff in ['True', 'False']:
-            queryset = queryset.filter(is_staff=(is_staff == 'True'))
-            
-        if is_superuser in ['True', 'False']:
-            queryset = queryset.filter(is_superuser=(is_superuser == 'True'))
-            
-        if groups and groups in self.__group_handles:
-            queryset = queryset.filter(groups__id=groups)
-
         return queryset
-    
+
 from django import forms
 
 class CustomActionForm(forms.Form):
     action = forms.ChoiceField(
-        label="작업",   
-        choices=[],           
+        label="작업",
+        choices=[],
         required=False,
     )
     select_across = forms.CharField(
         required=False,
-        widget=forms.HiddenInput(),   
+        widget=forms.HiddenInput(),
         label=''
     )
 
@@ -94,21 +80,34 @@ class CustomActionForm(forms.Form):
 class UserAdmin(OldUserAdmin):
     search_fields = ('username', 'email', 'first_name', 'last_name')
     list_display = ('username', 'email', 'first_name', 'staff_status', 'active_status', 'date_joined_display')
+    # 커스텀 필터만 사용 - Django 기본 필터들 완전히 제거
     list_filter = (
         ('username', UserCombinedInputFilter),
     )
+    filter_horizontal = ()  # groups, user_permissions 제거
     action_form = CustomActionForm
-    
 
-    
-    
+    # Django 기본 UserAdmin의 fieldsets 오버라이드 (필터와 관련 없지만 완전한 제어를 위해)
+    fieldsets = (
+        (None, {'fields': ('username', 'password')}),
+        (('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),
+        (('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser')}),
+        (('Important dates'), {'fields': ('last_login', 'date_joined')}),
+    )
+
+    def get_list_filter(self, request):
+        """Django 기본 필터를 제거하고 커스텀 필터만 반환"""
+        return (('username', UserCombinedInputFilter),)
+
+
+
     def staff_status(self, obj):
         """관리자 페이지에서 스태프 권한 유무를 pill 스타일로 표시"""
         if obj.is_staff:
             return format_html('<span class="pill pill-success">있음</span>')
         else:
             return format_html('<span class="pill pill-neutral">없음</span>')
-    
+
     staff_status.admin_order_field = 'is_staff'
     staff_status.short_description = _('스태프 권한')
 
@@ -118,7 +117,7 @@ class UserAdmin(OldUserAdmin):
             return format_html('<span class="pill pill-success">활성</span>')
         else:
             return format_html('<span class="pill pill-danger">비활성</span>')
-    
+
     active_status.admin_order_field = 'is_active'
     active_status.short_description = _('활성 상태')
 
@@ -127,10 +126,10 @@ class UserAdmin(OldUserAdmin):
         if obj.date_joined:
             return obj.date_joined.strftime('%Y. %m. %d. %H:%M')
         return '-'
-    
+
     date_joined_display.admin_order_field = 'date_joined'
     date_joined_display.short_description = _('가입 시간')
-    
+
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if not change:

--- a/site/templates/admin/input_filter/input_filter_user.html
+++ b/site/templates/admin/input_filter/input_filter_user.html
@@ -1,6 +1,6 @@
 <head>
-  <link 
-    rel="stylesheet" 
+  <link
+    rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
   >
 </head>
@@ -22,41 +22,6 @@
 <label>
   이름
   <input type="text" name="first_name" value="{{ request.GET.first_name }}" placeholder="이름">
-</label>
-<label>
-  활성 상태
-  <select name="is_active">
-    <option value="">모두</option>
-    <option value="True" {% if request.GET.is_active == "True" %}selected{% endif %}>활성</option>
-    <option value="False" {% if request.GET.is_active == "False" %}selected{% endif %}>비활성</option>
-  </select>
-</label>
-<label>
-  스태프 권한
-  <select name="is_staff">
-    <option value="">모두</option>
-    <option value="True" {% if request.GET.is_staff == "True" %}selected{% endif %}>있음</option>
-    <option value="False" {% if request.GET.is_staff == "False" %}selected{% endif %}>없음</option>
-  </select>
-</label>
-<label>
-  최상위 사용자 권한
-  <select name="is_superuser">
-    <option value="">모두</option>
-    <option value="True" {% if request.GET.is_superuser == "True" %}selected{% endif %}>있음</option>
-    <option value="False" {% if request.GET.is_superuser == "False" %}selected{% endif %}>없음</option>
-  </select>
-</label>
-<label>
-  그룹
-  <select name="groups">
-    <option value="">모두</option>
-    {% for value, label in spec.group_lookups %}
-      <option value="{{ value }}" {% if request.GET.groups == value %}selected{% endif %}>
-        {{ label }}
-      </option>
-    {% endfor %}
-  </select>
 </label>
 
   <button type="submit" style="font-size: 14px;">

--- a/site/templates/wpadmin/menu/left_menu.html
+++ b/site/templates/wpadmin/menu/left_menu.html
@@ -287,6 +287,7 @@
             background-color:#E6E7EA;
             align-items: center;
             padding-left:15px;
+            padding-bottom: 15px;
         }
         #content #content-main #changelist #changelist-filter form label {
             display: flex;
@@ -303,7 +304,8 @@
             color: white;
             margin-left : auto;
             margin-right : 12px;
-            align-self: center;
+            align-self: flex-end;
+            margin-bottom: 8px;
             height: 30px;
             box-shadow:none;
             border:none;


### PR DESCRIPTION
# 1. 필터 적용 버튼 위치 조정

## 기존
<img width="1572" height="95" alt="image" src="https://github.com/user-attachments/assets/3c0e9085-c39a-4372-912f-89c9d995192e" />

## 수정 후
<img width="1576" height="115" alt="image" src="https://github.com/user-attachments/assets/edcc505f-cf75-4d9d-9a25-e4d13d115025" />

### >> 1번 설명: 배경의 아래쪽을 확장하고, 필터 적용 버튼과 input창의 위치 맞춤 설정

# 2. 프로파일 탭에 있는 구버전 필터 삭제

## 기존
<img width="1683" height="275" alt="image" src="https://github.com/user-attachments/assets/c66b3c78-87cb-47cc-87fc-bfa795dbb36d" />

## 수정 후
<img width="1672" height="269" alt="image" src="https://github.com/user-attachments/assets/71b03397-f1bc-4113-96ac-6baaf74febd0" />

### >> 2번 설명: 필터 적용 버튼 외에 다른 부분에서 적용하는 필터 기능(구버전) 삭제