### PR TITLE
fix: JEduTools 회원가입 후 Litmus 회원가입 창으로 바로 리다이렉션하도록 수정

### DIFF
--- a/site/dmoj/settings.example.py
+++ b/site/dmoj/settings.example.py
@@ -670,5 +670,3 @@ except IOError:
 # Check settings are consistent
 assert DMOJ_PROBLEM_MIN_USER_POINTS_VOTE >= DMOJ_PROBLEM_MIN_PROBLEM_POINTS
 
-
-

--- a/site/judge/custom_pipeline.py
+++ b/site/judge/custom_pipeline.py
@@ -3,7 +3,9 @@ import re
 import json
 from operator import itemgetter
 from django import forms
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.models import User
 from social_core.pipeline.partial import partial
@@ -27,5 +29,5 @@ def check_existing_user(backend, user, *args, **kwargs):
     if user is None:
         request = backend.strategy.request
         request.session.flush()
-        raise AuthException(backend, "최초 JEduTools 통합 로그인 시 Litmus 회원가입 후 로그인 해주세요.")
+        return HttpResponseRedirect(reverse('registration_register'))
     return {}


### PR DESCRIPTION
### What
- Litmus를 처음 사용하는 사용자에 대해 : JEduTools 로그인 후 Litmus 페이지로 다시 돌아올 때 인증 실패 창이 뜨는 문제
- 다시 한번 Litmus 회원가입 창을 들어가서 사용자 정보(학번 등)를 입력 후 가입(저장)해야 하는 문제
<img width="1331" height="314" alt="image" src="https://github.com/user-attachments/assets/be6f7240-1090-4e7a-9b29-20e22e6dc211" />

### How
``` return HttpResponseRedirect(reverse('registration_register')) ``` 구문 추가
<img width="970" height="867" alt="image" src="https://github.com/user-attachments/assets/ba64bb1a-18b7-4f5e-a97e-c01a0edef88b" />
- JEduTools 가입 후 Litmus 가입창으로 리다이렉션 되도록 수정해 해결
- JEduTools 가입 후 Litmus 가입을 완료하는 시나리오가 되도록 수정 완료 