### PR TITLE
Secure/restart

### DIFF
--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -68,7 +68,7 @@
     {% endif %}
     {% block media %}{% endblock %}
     {% if not INLINE_JQUERY %}
-        <script src="{{ JQUERY_JS }}"></script>
+        <script nonce="{{ request.csp_nonce }}" src="{{ JQUERY_JS }}"></script>
     {% endif %}
 
     {% compress js %}


### PR DESCRIPTION
- strict-dynamic 지시문과 관련된 잘못된 구성 문제 해결
- 스크립트 허용 목록 구성의 우회 문제 해결
- 누락된 "Content-Security-Policy" 헤더 문제 해결