### PR TITLE
Secure/restart

### DIFF
--- a/site/judge/middleware.py
+++ b/site/judge/middleware.py
@@ -250,25 +250,6 @@ class KeycloakSSOMiddleware(MiddlewareMixin):
 class SimpleCSPMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-<<<<<<< HEAD
-
-    def __call__(self, request):
-        nonce = base64.b64encode(secrets.token_bytes(16)).decode('ascii')
-        request.csp_nonce = nonce
-
-        response = self.get_response(request)
-        # unsafe-inline 제거
-        response['Content-Security-Policy'] = (
-            f"default-src 'self'; "
-            f"script-src 'self' 'nonce-{nonce}' 'strict-dynamic' cdnjs.cloudflare.com ajax.googleapis.com; "
-            f"style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com maxcdn.bootstrapcdn.com; "
-            f"font-src 'self' maxcdn.bootstrapcdn.com cdnjs.cloudflare.com; "
-            f"img-src 'self' data: www.gravatar.com gravatar.com; "
-            f"frame-ancestors 'none'; "
-            f"object-src 'none'"
-        )
-
-=======
         self.csp_value = getattr(
             settings,
             'CSP_HEADER_VALUE',
@@ -320,7 +301,6 @@ class SimpleCSPMiddleware:
             except Exception:
                 # If anything goes wrong, leave the response unchanged.
                 pass
->>>>>>> d29b99b (strict-dynamic,스크립트 허용목록,누락된CSP해결)
         return response
     
 class NoCacheMiddleware:

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -68,7 +68,7 @@
     {% endif %}
     {% block media %}{% endblock %}
     {% if not INLINE_JQUERY %}
-        <script src="{{ JQUERY_JS }}"></script>
+        <script nonce="{{ request.csp_nonce }}" src="{{ JQUERY_JS }}"></script>
     {% endif %}
 
     {% compress js %}


### PR DESCRIPTION
- strict-dynamic 지시문과 관련된 잘못된 구성 해결
- 스크립트 허용 목록 구성의 우회 해결
- 누락된 "Content-Security-Policy" 헤더 해결