### PR TITLE
Jo030304/fix admin user tools hover position

### DIFF
--- a/site/templates/admin/base_site.html
+++ b/site/templates/admin/base_site.html
@@ -191,6 +191,14 @@
 </style>
 {% endblock %}
 
+{% block wpadmin_extrastyle %}
+<style>
+  #adminbarwrap #adminbar .wp-user-tools .wp-submenu {
+    left: -100px;
+  }
+</style>
+{% endblock %}
+
 {% block title %}{{ title }} | {% wpadmin_render_custom_title %}{% endblock %}
 
 {% block branding %}

--- a/site/templates/admin/base_site.html
+++ b/site/templates/admin/base_site.html
@@ -194,7 +194,8 @@
 {% block wpadmin_extrastyle %}
 <style>
   #adminbarwrap #adminbar .wp-user-tools .wp-submenu {
-    left: -100px;
+    left: auto;
+    right: 0;
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
## 기존
<img width="1952" height="955" alt="image" src="https://github.com/user-attachments/assets/5d0c6188-187a-41d2-9b07-bad8dfc07417" />

## 수정 후
<img width="1953" height="944" alt="image" src="https://github.com/user-attachments/assets/37f21ea6-f8ab-4f1c-8fe9-7561aa3ace02" />

### <관리자 프로필 드롭다운 바의 위치를 프로필 바의 오른쪽에 맞추게끔 조정했습니다.>