### PR TITLE
fix: contest 총점 재계산 race condition 방지

### DIFF
--- a/site/judge/models/contest.py
+++ b/site/judge/models/contest.py
@@ -540,6 +540,9 @@ class ContestParticipation(models.Model):
 
     def recompute_results(self):
         with transaction.atomic():
+            # 같은 participation에 대한 동시 recompute를 직렬화하여 race condition 방지
+            ContestParticipation.objects.select_for_update().filter(id=self.id).get()
+
             # problem_first_solved 필드가 없는 경우 초기화
             if self.problem_first_solved is None:
                 self.problem_first_solved = {}


### PR DESCRIPTION
문제:
동시 채점 완료 시 recompute_results()가 병렬 실행되어
ContestParticipation 총점이 stale 값으로 덮어씌워지는 문제 수정
-> 한 사람이 빠른 다중 제출하면 contest 통계에서 일부 제출 누락

해결:
총점 재계산시 DB에 Lock을 걸어 동시 실행을 순차 처리하도록 변경