### PR TITLE
secure: 2025_SW_security_patch(1/2)

### DIFF
--- a/site/dmoj/settings.example.py
+++ b/site/dmoj/settings.example.py
@@ -438,8 +438,7 @@ BLEACH_USER_SAFE_TAGS = [
     'ul', 'ol', 'li', 'dd', 'dl', 'dt', 'address', 'section', 'details', 'summary',
     'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption', 'colgroup', 'col', 'tfoot',
     'img', 'audio', 'video', 'source',
-    'a',
-    'style', 'noscript', 'center',
+    'a', 'noscript', 'center',
 ]
 
 BLEACH_USER_SAFE_ATTRS = {

--- a/site/judge/forms.py
+++ b/site/judge/forms.py
@@ -30,6 +30,7 @@ from importlib import import_module
 from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
 from bleach import clean
+from django.utils import timezone
 
 User = get_user_model()
 
@@ -96,14 +97,15 @@ class ProfileForm(ModelForm):
         about = self.cleaned_data['about']
         if len(about) > 1000:
             raise ValidationError(_('자기소개는 1000자 이내로 작성해주세요.'))
-        
+
+        allowed_tags = [tag for tag in settings.BLEACH_USER_SAFE_TAGS if tag != 'style']
         sanitized_about = clean(
             about,
-            tags=settings.BLEACH_USER_SAFE_TAGS,
+            tags=allowed_tags,
             attributes=settings.BLEACH_USER_SAFE_ATTRS,
             strip=True
         )
-        
+
         return sanitized_about
 
     # def clean(self):
@@ -194,10 +196,13 @@ class CustomAuthenticationForm(AuthenticationForm):
             "아이디 또는 비밀번호가 잘못되었습니다."
         ),
         'inactive': _("인증이 완료되지 않은 계정입니다."),
+        'account_locked': _("로그인 시도가 너무 많습니다. 10분 후 다시 시도해 주세요."),
     }
 
     def __init__(self, *args, **kwargs):
         super(CustomAuthenticationForm, self).__init__(*args, **kwargs)
+        self.login_failure_status_message = ''
+        self.login_lock_notice_message = _('아이디 또는 비밀번호를 5회 이상 잘못 입력하면\n10분 동안 로그인이 잠깁니다.')
         self.fields['username'].widget.attrs.update({
             'placeholder': _('아이디를 입력해 주세요'),
             'autocomplete': 'off'
@@ -220,19 +225,139 @@ class CustomAuthenticationForm(AuthenticationForm):
         password = self.cleaned_data.get('password')
 
         if username is not None and password:
+            profile = self._get_profile(username)
+            if profile is not None and profile.is_login_locked():
+                self.add_error('username', self.error_messages['account_locked'])
+                return self.cleaned_data
+            if profile is None and self._is_session_login_locked(username):
+                self.add_error('username', self.error_messages['account_locked'])
+                return self.cleaned_data
+
+            authenticated_user = None
+            authenticated_backend_path = None
             for backend_path in settings.AUTHENTICATION_BACKENDS:
                 backend = self._get_backend(backend_path)
                 if backend:
                     user = self._try_login_with_backend(backend, username, password)
                     if user:
-                        self.confirm_login_allowed(user)
-                        user.backend = backend_path
-                        self.user_cache = user
+                        authenticated_user = user
+                        authenticated_backend_path = backend_path
                         break
+
+            if authenticated_user is not None:
+                self.confirm_login_allowed(authenticated_user)
+                authenticated_user.backend = authenticated_backend_path
+                self.user_cache = authenticated_user
+                profile = profile or getattr(authenticated_user, 'profile', None)
+                if profile is not None:
+                    profile.clear_login_failures()
+                self._clear_session_login_failures(username)
             else:
-                self.add_error('username', self.error_messages['invalid_login'])
+                if profile is not None:
+                    if profile.register_login_failure():
+                        self.add_error('username', self.error_messages['account_locked'])
+                        return self.cleaned_data
+                    self.login_failure_status_message = self._get_login_failure_status_message(profile)
+                    self.add_error('username', self._get_invalid_login_message(profile))
+                else:
+                    current_attempt, is_locked = self._register_session_login_failure(username)
+                    if is_locked:
+                        self.add_error('username', self.error_messages['account_locked'])
+                        return self.cleaned_data
+                    self.login_failure_status_message = self._format_login_failure_status_message(current_attempt)
+                    self.add_error('username', self._format_invalid_login_message(current_attempt))
 
         return self.cleaned_data
+
+    def _get_invalid_login_message(self, profile):
+        if profile is None:
+            return self.error_messages['invalid_login']
+
+        return self._format_invalid_login_message(profile.failed_login_attempts)
+
+    def _get_login_failure_status_message(self, profile):
+        if profile is None:
+            return ''
+
+        return self._format_login_failure_status_message(profile.failed_login_attempts)
+
+    def _format_invalid_login_message(self, current_attempt):
+        return self.error_messages['invalid_login']
+
+    def _format_login_failure_status_message(self, current_attempt):
+        return _('현재 로그인 실패: %(current_attempt)d/%(max_attempts)d회') % {
+            'current_attempt': current_attempt,
+            'max_attempts': Profile.LOGIN_FAILURE_LIMIT,
+        }
+
+    def _session_login_failures(self):
+        if not hasattr(self, 'request') or self.request is None:
+            return {}
+        return self.request.session.setdefault('login_failure_tracker', {})
+
+    def _session_login_failure_key(self, username):
+        return (username or '').strip().lower()
+
+    def _is_session_login_locked(self, username):
+        if not hasattr(self, 'request') or self.request is None:
+            return False
+
+        tracker = self._session_login_failures()
+        data = tracker.get(self._session_login_failure_key(username))
+        if not data:
+            return False
+
+        locked_until = data.get('locked_until')
+        if not locked_until:
+            return False
+
+        return timezone.now().timestamp() < locked_until
+
+    def _register_session_login_failure(self, username):
+        if not hasattr(self, 'request') or self.request is None:
+            return 0, False
+
+        tracker = self._session_login_failures()
+        key = self._session_login_failure_key(username)
+        now_ts = timezone.now().timestamp()
+        data = tracker.get(key, {'count': 0, 'locked_until': None})
+
+        if data.get('locked_until') and now_ts < data['locked_until']:
+            return 0, True
+
+        data['count'] = data.get('count', 0) + 1
+        data['locked_until'] = None
+
+        if data['count'] >= Profile.LOGIN_FAILURE_LIMIT:
+            data = {
+                'count': 0,
+                'locked_until': (timezone.now() + Profile.LOGIN_LOCK_DURATION).timestamp(),
+            }
+            tracker[key] = data
+            self.request.session.modified = True
+            return 0, True
+
+        tracker[key] = data
+        self.request.session.modified = True
+        return data['count'], False
+
+    def _clear_session_login_failures(self, username):
+        if not hasattr(self, 'request') or self.request is None:
+            return
+
+        tracker = self.request.session.get('login_failure_tracker', {})
+        key = self._session_login_failure_key(username)
+        if key in tracker:
+            del tracker[key]
+            self.request.session.modified = True
+
+    def _get_profile(self, username):
+        user = User.objects.filter(username=username).first()
+        if user is None:
+            return None
+
+        profile, _ = Profile.objects.get_or_create(user=user)
+        return profile
 
     def _get_backend(self, backend_path):
         try:

--- a/site/judge/migrations/0031_profile_login_lock_fields.py
+++ b/site/judge/migrations/0031_profile_login_lock_fields.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0030_profile_site_theme'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='failed_login_attempts',
+            field=models.PositiveSmallIntegerField(default=0, verbose_name='failed login attempts'),
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='login_locked_until',
+            field=models.DateTimeField(blank=True, null=True, verbose_name='login locked until'),
+        ),
+    ]

--- a/site/judge/models/profile.py
+++ b/site/judge/models/profile.py
@@ -3,6 +3,7 @@ import hmac
 import json
 import secrets
 import struct
+from datetime import timedelta
 from operator import mul
 
 import pyotp
@@ -190,6 +191,9 @@ class School(models.Model):
         verbose_name_plural = _('학교')
 
 class Profile(models.Model):
+    LOGIN_FAILURE_LIMIT = 5
+    LOGIN_LOCK_DURATION = timedelta(minutes=10)
+
     user = models.OneToOneField(User, verbose_name=_('user associated'), on_delete=models.CASCADE)
     about = models.TextField(verbose_name=_('self-description'), null=True, blank=True)
     timezone = models.CharField(max_length=50, verbose_name=_('time zone'), choices=TIMEZONE,
@@ -256,6 +260,8 @@ class Profile(models.Model):
     data_last_downloaded = models.DateTimeField(verbose_name=_('last data download time'), null=True, blank=True)
     username_display_override = models.CharField(max_length=100, blank=True, verbose_name=_('display name override'),
                                                  help_text=_('Name displayed in place of username.'))
+    failed_login_attempts = models.PositiveSmallIntegerField(default=0, verbose_name=_('failed login attempts'))
+    login_locked_until = models.DateTimeField(null=True, blank=True, verbose_name=_('login locked until'))
 
     # @cached_property
     # def organization(self):
@@ -350,6 +356,43 @@ class Profile(models.Model):
         return False
 
     check_totp_code.alters_data = True
+
+    ## 계정이 잠겨있는지 확인
+    def is_login_locked(self, now=None):
+        now = now or timezone.now()
+        return self.login_locked_until is not None and self.login_locked_until > now
+
+    ## 5번 실패 했을 시, 초기화 하는 메서드
+    def clear_login_failures(self):
+        if self.failed_login_attempts or self.login_locked_until is not None:
+            self.failed_login_attempts = 0
+            self.login_locked_until = None
+            self.save(update_fields=['failed_login_attempts', 'login_locked_until'])
+
+    clear_login_failures.alters_data = True
+
+    ## 로그인을 5번 이상 틀릴 시 10분 잠금 
+    def register_login_failure(self, now=None):
+        now = now or timezone.now()
+
+        if self.is_login_locked(now=now):
+            return True
+
+        self.failed_login_attempts += 1
+        update_fields = ['failed_login_attempts']
+
+        if self.failed_login_attempts >= self.LOGIN_FAILURE_LIMIT:
+            self.failed_login_attempts = 0
+            self.login_locked_until = now + self.LOGIN_LOCK_DURATION
+            update_fields.append('login_locked_until')
+        elif self.login_locked_until is not None:
+            self.login_locked_until = None
+            update_fields.append('login_locked_until')
+
+        self.save(update_fields=update_fields)
+        return self.is_login_locked(now=now)
+
+    register_login_failure.alters_data = True
 
     def get_absolute_url(self):
         return reverse('user_page', args=(self.user.username,))

--- a/site/judge/models/tests/test_login_lockout.py
+++ b/site/judge/models/tests/test_login_lockout.py
@@ -1,0 +1,101 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from judge.forms import CustomAuthenticationForm
+from judge.models import Profile
+from judge.models.tests.util import CommonDataMixin
+
+
+class LoginLockoutTestCase(CommonDataMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = cls.users['normal']
+        cls.user.set_password('correct-password')
+        cls.user.save(update_fields=['password'])
+        cls.profile = cls.user.profile
+
+    def make_form(self, password):
+        return CustomAuthenticationForm(data={
+            'username': self.user.username,
+            'password': password,
+        })
+
+    def test_account_is_locked_after_five_failed_attempts(self):
+        base_time = timezone.now()
+
+        with patch('judge.models.profile.timezone.now', return_value=base_time):
+            form = self.make_form('wrong-password')
+            self.assertFalse(form.is_valid())
+            self.assertEqual(form.login_failure_status_message, '현재 로그인 실패: 1/5회')
+            self.assertEqual(form.errors['username'][0], '아이디 또는 비밀번호가 잘못되었습니다.')
+
+            for _ in range(3):
+                form = self.make_form('wrong-password')
+                self.assertFalse(form.is_valid())
+
+            self.profile.refresh_from_db()
+            self.assertEqual(self.profile.failed_login_attempts, 4)
+            self.assertIsNone(self.profile.login_locked_until)
+            self.assertEqual(form.login_failure_status_message, '현재 로그인 실패: 4/5회')
+            self.assertEqual(form.errors['username'][0], '아이디 또는 비밀번호가 잘못되었습니다.')
+
+            form = self.make_form('wrong-password')
+            self.assertFalse(form.is_valid())
+            self.assertEqual(form.login_failure_status_message, '')
+            self.assertEqual(form.errors['username'][0], '로그인 시도가 너무 많습니다. 10분 후 다시 시도해 주세요.')
+
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.failed_login_attempts, 0)
+        self.assertEqual(self.profile.login_locked_until, base_time + timedelta(minutes=10))
+
+        with patch('judge.models.profile.timezone.now', return_value=base_time + timedelta(minutes=1)):
+            form = self.make_form('correct-password')
+            self.assertFalse(form.is_valid())
+            self.assertEqual(form.errors['username'][0], '로그인 시도가 너무 많습니다. 10분 후 다시 시도해 주세요.')
+
+        with patch('judge.models.profile.timezone.now', return_value=base_time + timedelta(minutes=11)):
+            form = self.make_form('correct-password')
+            self.assertTrue(form.is_valid(), form.errors)
+
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.failed_login_attempts, 0)
+        self.assertIsNone(self.profile.login_locked_until)
+
+    def test_login_page_renders_failure_status_between_error_and_inputs(self):
+        response = self.client.post(reverse('auth_login'), data={
+            'username': self.user.username,
+            'password': 'wrong-password',
+        })
+
+        self.assertContains(response, '아이디 또는 비밀번호가 잘못되었습니다.')
+        self.assertContains(response, '현재 로그인 실패: 1/5회')
+
+        content = response.content.decode()
+        error_index = content.index('아이디 또는 비밀번호가 잘못되었습니다.')
+        status_index = content.index('현재 로그인 실패: 1/5회')
+        username_input_index = content.index('name="username"')
+
+        self.assertLess(error_index, status_index)
+        self.assertLess(status_index, username_input_index)
+
+    def test_login_failure_recreates_missing_profile_and_shows_counter(self):
+        Profile.objects.filter(user=self.user).delete()
+
+        form = self.make_form('wrong-password')
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.login_failure_status_message, '현재 로그인 실패: 1/5회')
+        self.assertTrue(Profile.objects.filter(user=self.user).exists())
+
+    def test_missing_username_still_shows_failure_counter(self):
+        response = self.client.post(reverse('auth_login'), data={
+            'username': 'definitely_missing_user',
+            'password': 'wrong-password',
+        })
+
+        self.assertContains(response, '아이디 또는 비밀번호가 잘못되었습니다.')
+        self.assertContains(response, '현재 로그인 실패: 1/5회')

--- a/site/judge/models/tests/test_profile_about_form.py
+++ b/site/judge/models/tests/test_profile_about_form.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+
+from judge.forms import ProfileForm
+from judge.models import Language
+from judge.models.tests.util import CommonDataMixin
+
+
+class ProfileAboutFormTestCase(CommonDataMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = cls.users['normal']
+        cls.profile = cls.user.profile
+        cls.language = Language.objects.get(pk=cls.profile.language_id)
+
+    def make_form(self, about):
+        return ProfileForm(
+            data={
+                'about': about,
+                'timezone': self.profile.timezone,
+                'language': self.language.pk,
+                'ace_theme': self.profile.ace_theme,
+                'site_theme': self.profile.site_theme,
+                'user_script': self.profile.user_script,
+                'math_engine': self.profile.math_engine,
+                'test_site': '',
+            },
+            instance=self.profile,
+            user=self.user,
+        )
+
+    def test_clean_about_strips_script_tag(self):
+        form = self.make_form('<script>alert(1)</script>hello')
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data['about'], 'alert(1)hello')
+
+    def test_clean_about_strips_style_tag(self):
+        form = self.make_form('<style>body{color:red}</style>hello')
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data['about'], 'body{color:red}hello')

--- a/site/judge/signals.py
+++ b/site/judge/signals.py
@@ -108,12 +108,20 @@ def profile_update(sender, instance, **kwargs):
     if hasattr(instance, '_updating_stats_only'):
         return
 
-    # cache.delete_many([make_template_fragment_key('user_about', (instance.id, engine))
-    #                    for engine in EFFECTIVE_MATH_ENGINES] +
-    #                   [make_template_fragment_key('org_member_count', (org_id,))
-    #                    for org_id in instance.organizations.values_list('id', flat=True)])
-    cache.delete_many([make_template_fragment_key('user_about', (instance.id, engine))
-                    for engine in EFFECTIVE_MATH_ENGINES])
+    cache.delete_many(
+        [make_template_fragment_key('user_about', (instance.id, engine))
+         for engine in EFFECTIVE_MATH_ENGINES] +
+        [make_template_fragment_key('user_about_text', (instance.id, engine))
+         for engine in EFFECTIVE_MATH_ENGINES]
+    )
+
+
+@receiver(post_save, sender=User)
+def ensure_user_profile(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    Profile.objects.get_or_create(user=instance)
 
 
 @receiver(post_delete, sender=WebAuthnCredential)

--- a/site/judge/views/contests.py
+++ b/site/judge/views/contests.py
@@ -69,7 +69,9 @@ import logging
 @csrf_exempt
 def verify_contest_code(request, contest_key):
     data = json.loads(request.body)
-    entered_code = data.get('code')
+    entered_code = data.get('code') or ''
+    if len(entered_code) > 30:
+        return JsonResponse({'valid': False, 'error': '비정상적인 접근입니다.'})
     user = request.user  # 로그인된 사용자
     profile = request.profile  # 사용자의 프로필
 
@@ -916,7 +918,7 @@ class ContestAccessDenied(Exception):
 
 
 class ContestAccessCodeForm(forms.Form):
-    access_code = forms.CharField(max_length=255)
+    access_code = forms.CharField(max_length=30)
 
     def __init__(self, *args, **kwargs):
         super(ContestAccessCodeForm, self).__init__(*args, **kwargs)

--- a/site/templates/contest/contest-tabs.html
+++ b/site/templates/contest/contest-tabs.html
@@ -46,12 +46,68 @@
                 submitContestCode();
             });
         }
+        const joinContestCodeInput = document.getElementById("join-contest-code");
+        if (joinContestCodeInput) {
+            joinContestCodeInput.addEventListener("input", function() {
+                isJoinContestCodeLengthValid(this.value);
+            });
+            joinContestCodeInput.addEventListener("beforeinput", function(event) {
+                if (event.inputType && event.inputType.indexOf("delete") === 0) {
+                    toggleJoinContestCodeError("");
+                    return;
+                }
+                if (willJoinContestCodeExceedLimit(this, event.data || "")) {
+                    event.preventDefault();
+                    toggleJoinContestCodeError("비정상적인 접근입니다.");
+                }
+            });
+            joinContestCodeInput.addEventListener("paste", function(event) {
+                const pastedText = (event.clipboardData || window.clipboardData).getData("text");
+                if (willJoinContestCodeExceedLimit(this, pastedText)) {
+                    event.preventDefault();
+                    toggleJoinContestCodeError("비정상적인 접근입니다.");
+                }
+            });
+        }
     });
+
+    function toggleJoinContestCodeError(message) {
+        const errorElement = document.getElementById("join-contest-code-error");
+        if (!errorElement) return;
+        if (message) {
+            errorElement.textContent = message;
+            errorElement.style.display = "block";
+        } else {
+            errorElement.textContent = "";
+            errorElement.style.display = "none";
+        }
+    }
+
+    function isJoinContestCodeLengthValid(code) {
+        if (code.length > 30) {
+            toggleJoinContestCodeError("비정상적인 접근입니다.");
+            return false;
+        }
+        toggleJoinContestCodeError("");
+        return true;
+    }
+
+    function willJoinContestCodeExceedLimit(input, insertedText) {
+        const currentValue = input.value || "";
+        const selectionStart = input.selectionStart == null ? currentValue.length : input.selectionStart;
+        const selectionEnd = input.selectionEnd == null ? currentValue.length : input.selectionEnd;
+        const nextValue = currentValue.slice(0, selectionStart) + insertedText + currentValue.slice(selectionEnd);
+        return nextValue.length > 30;
+    }
 
     // 코드 검증 함수
     function submitContestCode() {
         const contestKey = document.getElementById("join-contest-modal").getAttribute('data-contest-key');
         const enteredCode = document.getElementById("join-contest-code").value;
+
+        if (!isJoinContestCodeLengthValid(enteredCode)) {
+            return;
+        }
 
         // 입력된 코드 검증을 위한 API 요청
         fetch(`/api/contest/${contestKey}/verify-code/`, {
@@ -227,10 +283,17 @@
         text-align: center;
         font-size: 30px;
     }
-    #join-contest-code, #join-contest-submit {
+    #join-contest-code {
         width: 266px;
         height: 40px;
         border-radius: 8px;
+        margin-bottom: 0;
+    }
+    #join-contest-submit {
+        width: 266px;
+        height: 40px;
+        border-radius: 8px;
+        margin-top: 12px;
         margin-bottom: 15px;
     }
     #contest-code-title {
@@ -274,7 +337,8 @@
         </div>
         <div class="modal_content">
             <div id="contest-code-title">대회 참여 코드</div>
-            <input type="text" id="join-contest-code" name="join-contest-code" maxlength="100" placeholder="대회 참여 코드를 입력해 주세요">
+            <input type="text" id="join-contest-code" name="join-contest-code" maxlength="30" placeholder="대회 참여 코드를 입력해 주세요">
+            <div id="join-contest-code-error" style="display:none;color:red;margin:4px 0 0 0;line-height:1.3;text-align:left;">비정상적인 접근입니다.</div>
             <button id="join-contest-submit" type="submit">대회 입장하기</button>
         </div>
     </div>

--- a/site/templates/contest/list.html
+++ b/site/templates/contest/list.html
@@ -281,10 +281,17 @@
             text-align: center;
             font-size: 30px;
         }
-        #contest-code, #contest-code-button {
+        #contest-code {
             width: 266px;
             height: 40px;
             border-radius: 8px;
+            margin-bottom: 0;
+        }
+        #contest-code-button {
+            width: 266px;
+            height: 40px;
+            border-radius: 8px;
+            margin-top: 12px;
             margin-bottom: 15px;
         }
         #contest-code-title {
@@ -352,6 +359,29 @@
                     submitContestCode();
                 });
             }
+            const contestCodeInput = document.getElementById("contest-code");
+            if (contestCodeInput) {
+                contestCodeInput.addEventListener("input", function() {
+                    isContestCodeLengthValid(this.value);
+                });
+                contestCodeInput.addEventListener("beforeinput", function(event) {
+                    if (event.inputType && event.inputType.indexOf("delete") === 0) {
+                        toggleContestCodeError("");
+                        return;
+                    }
+                    if (willContestCodeExceedLimit(this, event.data || "")) {
+                        event.preventDefault();
+                        toggleContestCodeError("비정상적인 접근입니다.");
+                    }
+                });
+                contestCodeInput.addEventListener("paste", function(event) {
+                    const pastedText = (event.clipboardData || window.clipboardData).getData("text");
+                    if (willContestCodeExceedLimit(this, pastedText)) {
+                        event.preventDefault();
+                        toggleContestCodeError("비정상적인 접근입니다.");
+                    }
+                });
+            }
 
             document.getElementById("all_subjects").addEventListener('change', function() {
                 if (this.checked) {
@@ -408,9 +438,42 @@
 
         });
     
+        function toggleContestCodeError(message) {
+            const errorElement = document.getElementById("contest-code-error");
+            if (!errorElement) return;
+            if (message) {
+                errorElement.textContent = message;
+                errorElement.style.display = "block";
+            } else {
+                errorElement.textContent = "";
+                errorElement.style.display = "none";
+            }
+        }
+
+        function isContestCodeLengthValid(code) {
+            if (code.length > 30) {
+                toggleContestCodeError("비정상적인 접근입니다.");
+                return false;
+            }
+            toggleContestCodeError("");
+            return true;
+        }
+
+        function willContestCodeExceedLimit(input, insertedText) {
+            const currentValue = input.value || "";
+            const selectionStart = input.selectionStart == null ? currentValue.length : input.selectionStart;
+            const selectionEnd = input.selectionEnd == null ? currentValue.length : input.selectionEnd;
+            const nextValue = currentValue.slice(0, selectionStart) + insertedText + currentValue.slice(selectionEnd);
+            return nextValue.length > 30;
+        }
+
         function submitContestCode() {
             const contestKey = document.getElementById("contest-modal").getAttribute('data-contest-key');
             const enteredCode = document.getElementById("contest-code").value;
+
+            if (!isContestCodeLengthValid(enteredCode)) {
+                return;
+            }
     
             fetch(`/api/contest/${contestKey}/verify-code/`, {
                 method: 'POST',
@@ -608,7 +671,8 @@
                 </div>
                 <div class="modal_content">
                     <div id="contest-code-title">대회 참여 코드</div>
-                    <input type="text" id="contest-code" name="contest-code" maxlength="100" required placeholder="대회 참여 코드를 입력해 주세요">
+                    <input type="text" id="contest-code" name="contest-code" maxlength="30" required placeholder="대회 참여 코드를 입력해 주세요">
+                    <div id="contest-code-error" style="display:none;color:red;margin:4px 0 0 0;line-height:1.3;text-align:left;">비정상적인 접근입니다.</div>
                     <button id="contest-code-button" type="submit">대회 입장하기</button>
                 </div>
             </div>

--- a/site/templates/registration/login-admin.html
+++ b/site/templates/registration/login-admin.html
@@ -41,7 +41,7 @@
     }
 
     .auth-flow-form h2 {
-        margin-bottom: 20px;
+        margin-bottom: 0;
         font-size: 24px;
         font-weight: 400;
     }
@@ -147,6 +147,36 @@
     input[type=checkbox] {
         vertical-align: middle;
     }
+
+    .login-lock-notice {
+        display: block;
+        align-self: stretch;
+        width: 100%;
+        max-width: 100%;
+        margin: -4px 0 4px;
+        font-size: 14px;
+        font-weight: 400;
+        color: #222;
+        text-align: center;
+        white-space: pre-line;
+    }
+
+    .login-failure-status {
+        align-self: flex-start;
+        margin-bottom: 4px;
+        font-size: 14px;
+        font-weight: 400;
+        color: #D64545;
+    }
+
+    #form-errors.invalid_login,
+    #form-errors.invalid_login .error {
+        color: #D64545;
+    }
+
+    #form-errors.invalid_login .error {
+        white-space: pre-line;
+    }
 </style>
 {% endblock %}
 
@@ -155,14 +185,13 @@
     <h2>관리자 로그인</h2>
     <form action="" method="post" class="form-area">
         {% csrf_token %}
+        <div class="login-lock-notice">
+            {{ form.login_lock_notice_message }}
+        </div>
         {% if form.errors %}
             {% for field, errors in form.errors.items() %}
                 {% for error in errors %}
-                    {% if error == form.error_messages.invalid_login %}
-                        <div id="form-errors" class="invalid_login">
-                            <p class="error">{{ error }}</p>
-                        </div>
-                    {% elif error == form.error_messages.inactive %}
+                    {% if error == form.error_messages.inactive %}
                         <div id="form-errors" class="inactive">
                             <p class="error">{{ error }}</p>
                             <p>도움이 필요하신가요?</p>
@@ -172,12 +201,17 @@
                             </p>
                         </div>
                     {% else %}
-                        <div id="form-errors">
+                        <div id="form-errors" class="invalid_login">
                             <p class="error">{{ error }}</p>
                         </div>
                     {% endif %}
                 {% endfor %}
             {% endfor %}
+        {% endif %}
+        {% if form.login_failure_status_message %}
+        <div class="form-links login-failure-status">
+            {{ form.login_failure_status_message }}
+        </div>
         {% endif %}
         {{ form.username }}
         {{ form.password }}

--- a/site/templates/registration/login.html
+++ b/site/templates/registration/login.html
@@ -48,7 +48,7 @@
     }
 
     .auth-flow-form h2 {
-        margin-bottom: 20px;
+        margin-bottom: 0;
         font-size: 24px;
         font-weight: 400;
     }
@@ -230,6 +230,36 @@
         margin-top: 10px;
         margin-bottom: 0;
     }
+
+    .login-lock-notice {
+        display: block;
+        align-self: stretch;
+        width: 100%;
+        max-width: 100%;
+        margin: -4px 0 4px;
+        font-size: 14px;
+        font-weight: 400;
+        color: var(--font-basic-black);
+        text-align: center;
+        white-space: pre-line;
+    }
+
+    .login-failure-status {
+        align-self: flex-start;
+        margin-bottom: 4px;
+        font-size: 14px;
+        font-weight: 400;
+        color: #D64545;
+    }
+
+    #form-errors.invalid_login,
+    #form-errors.invalid_login .error {
+        color: #D64545;
+    }
+
+    #form-errors.invalid_login .error {
+        white-space: pre-line;
+    }
 </style>
 {% endblock %}
 
@@ -252,15 +282,14 @@
     <form action="" method="post" class="form-area">
         {% csrf_token %}
 
+        <div class="login-lock-notice">
+            {{ form.login_lock_notice_message }}
+        </div>
         <!-- 관리자 로그인 -->
         {% if form.errors %}
             {% for field, errors in form.errors.items() %}
                 {% for error in errors %}
-                    {% if error == form.error_messages.invalid_login %}
-                    <div id="form-errors" class="invalid_login">
-                        <p class="error">{{ error }}</p>
-                    </div>
-                    {% elif error == form.error_messages.inactive %}
+                    {% if error == form.error_messages.inactive %}
                     <div id="form-errors" class="inactive">
                         <p class="error">{{ error }}</p>
                         <p>도움이 필요하신가요?</p>
@@ -270,14 +299,18 @@
                         </p>
                     </div>
                     {% else %}
-                    <div id="form-errors">
+                    <div id="form-errors" class="invalid_login">
                         <p class="error">{{ error }}</p>
                     </div>
                     {% endif %}
                 {% endfor %}
             {% endfor %}
         {% endif %}
-
+        {% if form.login_failure_status_message %}
+        <div class="form-links login-failure-status">
+            {{ form.login_failure_status_message }}
+        </div>
+        {% endif %}
         {{ form.username }}
         {{ form.password }}
         <div class="form-links">


### PR DESCRIPTION
1. 버퍼 오버플로우
- 입력란 및 url에 다량의 문자열을 대입할 경우, 메모리가 고갈되어 "Out of Memory" 오류 발생
- 414 에러가 발생하며 서버의 구성 정보가 화면에 그대로 노출되는 문제

*해결 방안* : 입력란에 maxlength 설정 + 
프로필 수정란에 캐쉬가 저장되어 있어, 자기소개란을 변경하여도 바로 바뀌지 않는 문제 해결

<img width="1248" height="2192" alt="image" src="https://github.com/user-attachments/assets/ca8604cc-cbb3-4b43-8541-693547158b0a" />

<img width="2094" height="1732" alt="image" src="https://github.com/user-attachments/assets/cf347ccd-f5f9-4971-a777-00c6abbdcfcd" />



2. 정보 누출
- 서버의 운영체제, 웹 서버 소프트웨어의 종류, 버전 등 시스템의 아키텍처를 유추할 수 있는 모든 데이터가 보이는 문제

*해결 방안*: nginx 설정에서 server_tokens off 사용 (이미 2026 보안에서 수정함) +
블랙리스트 기반이였던 robot.txt를 화이트리스트 기반 robot.txt로 수정

<img width="1280" height="1528" alt="image" src="https://github.com/user-attachments/assets/c40290de-9cde-4395-a5c6-27c03ad7b9bb" />

<img width="1280" height="1528" alt="image" src="https://github.com/user-attachments/assets/0426c5da-3170-4931-9398-7839a8afa084" />



3. 악성 콘텐츠 / XSS
- 프로필 자기소개에 팝업창을 띄우는 악의적 페이로드 삽입 ( 스크립트가 그대로 실행되는 문제)

*해결 방안* : script 명령어 중에 몇 개를 제외한 나머지는 다 떼고 자기소개 란에 저장하도록 수정
<img width="1280" height="1528" alt="image" src="https://github.com/user-attachments/assets/d93ed4cd-f30a-4c11-9e85-9fa8f28f5bd0" />

<img width="1280" height="1528" alt="image" src="https://github.com/user-attachments/assets/6b07e557-fee8-468a-a075-cf352e0aac17" />

<img width="1280" height="1528" alt="image" src="https://github.com/user-attachments/assets/2be31932-6ca2-4c72-a6ec-fb843a9d1029" />

4. 로그인 시도 횟수 제한
- 웹 사이트의 로그인 페이지에서 사용자가 ID/PW가 틀렸을 때, 재시도할 수 있는 횟수에 제한을 두지 않는 시스템적 결함

*해결 방안* : 아이디 또는 비밀번호를 5회 이상 틀릴 시, 10분 로그인 제한

<img width="1280" height="1528" alt="image" src="https://github.com/user-attachments/assets/f67f17f5-001c-4e39-a036-6e3861cbd0ac" />

=> DB 칼럼 추가됨(site/judge/migrations/0031_profile_login_lock_fields.py)
