### PR TITLE
fix: 소스코드 보기 복사 버튼이 제출 정보와 겹치는 문제 수정

### DIFF
--- a/site/templates/submission/source.html
+++ b/site/templates/submission/source.html
@@ -102,6 +102,7 @@
             color: var(--font-black);
         }
         .source-wrap {
+            position: relative;
             background: rgba(28, 59, 96, 0.06);
         }
 


### PR DESCRIPTION
**버그 원인**
나의 제출 > 보기 > 소스코드 보기 페이지에서 코드 복사 아이콘이
"채점기/시간/언어/이름" 정보 줄 위에 겹쳐서 표시됨

복사 버튼 .copy-btn-overlay는 position: absolute로 배치되는데, position: absolute 요소는
가장 가까운 positioned 을 기준으로 배치됨
버튼  .source-wrap에 position이 지정되지 않아, 그 위
.card-content(position: relative)를 기준으로 top:5px right:2px에 배치됨
.card-content의 우상단은 우측 정렬된 제출 정보 줄이 있는 자리라서
복사 아이콘이 그 텍스트 위에 겹침

**수정 내용**
site/templates/submission/source.html — .source-wrap CSS 규칙 수정

.source-wrap에 position: relative 추가
복사 버튼이 .card-content가 아닌 의도된 컨테이너(.source-wrap, 코드 영역)를
기준으로 배치되도록 함

**정리**
복사 버튼(.copy-btn-overlay)의 position: absolute 기준점이 잘못 잡혀
제출 정보 줄과 겹치던 CSS 버그를 수정. 버튼의 부모인 .source-wrap에
position: relative가 빠져 있어 기준 조상이 .card-content로 잘못 잡힌 것이 원인이며,
.source-wrap에 position: relative를 추가해 버튼이 코드 영역 기준으로 배치되도록 함

수정 전
<img width="1121" height="294" alt="asdfasdfasdf" src="https://github.com/user-attachments/assets/a64cc313-ae14-4c88-b08d-5e15fbc099d5" />


수정 후
<img width="1123" height="162" alt="스크린샷 2026-05-19 021739" src="https://github.com/user-attachments/assets/d80702b3-56dd-41d0-ac0b-87bcb7047a43" />



적용 인스턴스 url : http://113.198.66.76:18021/src/57186