### PR TITLE
feat: 관리자 페이지 문제 그룹별 필터 기능 개발

### DIFF
--- a/site/judge/admin/problem.py
+++ b/site/judge/admin/problem.py
@@ -27,8 +27,8 @@ from django.utils.html import format_html
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext, gettext_lazy as _, ngettext
 
-from judge.models import (Judge, Language, LanguageLimit, Problem, ProblemClarification, 
-                         ProblemData, ProblemPointsVote, ProblemTestCase, 
+from judge.models import (Judge, Language, LanguageLimit, Problem, ProblemClarification,
+                         ProblemData, ProblemGroup, ProblemPointsVote, ProblemTestCase,
                          ProblemTranslation, Profile, Solution)
 from judge.utils.views import NoBatchDeleteMixin
 #TestCase 처리를 위한 import
@@ -252,6 +252,7 @@ from django.db.models import Q
 class ProblemCombinedInputFilter(FieldListFilter):
     title=' '
     template = 'admin/input_filter/input_filter_problem.html'  # 커스텀 템플릿
+    filter_keys = ['is_public', 'encryption_status', 'authors', 'name', 'code', 'problem_group']
 
     def __init__(self, field, request, params, model, model_admin, field_path):
         super().__init__(field, request, params, model, model_admin, field_path)
@@ -264,10 +265,38 @@ class ProblemCombinedInputFilter(FieldListFilter):
             .values_list('user__username', flat=True)
             .distinct()
         )
+        self.__group_lookups = tuple(
+            (str(group_id), full_name)
+            for group_id, full_name in ProblemGroup.objects.values_list('id', 'full_name')
+        )
+        self.__group_handles = {group_id for group_id, _ in self.__group_lookups}
+
+    @property
+    def group_lookups(self):
+        return self.__group_lookups
+
+    @property
+    def grouped_group_lookups(self):
+        ungrouped = []
+        grouped = {}
+
+        for group_id, full_name in ProblemGroup.objects.order_by('full_name').values_list('id', 'full_name'):
+            parts = [part.strip() for part in full_name.split('/') if part.strip()]
+            if len(parts) <= 1:
+                ungrouped.append((str(group_id), full_name))
+                continue
+
+            parent_label = ' / '.join(parts[:-1])
+            child_label = parts[-1]
+            grouped.setdefault(parent_label, []).append((str(group_id), child_label))
+
+        return (
+            tuple(ungrouped),
+            tuple((parent_label, tuple(children)) for parent_label, children in grouped.items()),
+        )
 
     def expected_parameters(self):
-        # 여러 필드를 필터하므로 각 필드 이름을 명시
-        return ['is_public', 'encryption_status', 'authors', 'name','code']
+        return self.filter_keys
 
     def choices(self, changelist):
         yield {
@@ -282,6 +311,7 @@ class ProblemCombinedInputFilter(FieldListFilter):
         authors = request.GET.get('authors')
         name = request.GET.get('name')
         code = request.GET.get('code')
+        problem_group = request.GET.get('problem_group')
 
         if is_public in ['True', 'False']:
             queryset = queryset.filter(is_public=(is_public == 'True'))
@@ -299,6 +329,9 @@ class ProblemCombinedInputFilter(FieldListFilter):
             
         if name:
             queryset = queryset.filter(name__icontains=name)
+
+        if problem_group and problem_group in self.__group_handles:
+            queryset = queryset.filter(group_id=problem_group)
 
             
         return queryset

--- a/site/judge/models/tests/test_admin_problem.py
+++ b/site/judge/models/tests/test_admin_problem.py
@@ -1,0 +1,69 @@
+from django.contrib import admin
+from django.test import RequestFactory, TestCase
+
+from judge.admin.problem import ProblemAdmin, ProblemCombinedInputFilter
+from judge.models import Problem
+from judge.models.tests.util import CommonDataMixin, create_problem
+
+
+class ProblemAdminFilterTest(CommonDataMixin, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.factory = RequestFactory()
+        cls.problem_admin = ProblemAdmin(Problem, admin.site)
+        cls.algorithm_problem = create_problem(code='alg001', group='algorithm')
+        cls.contest_problem = create_problem(code='jbn001', group='JBNUPC')
+
+    def build_filter(self, params=None):
+        request = self.factory.get('/admin/judge/problem/', params or {})
+        return ProblemCombinedInputFilter(
+            Problem._meta.get_field('name'),
+            request,
+            request.GET.copy(),
+            Problem,
+            self.problem_admin,
+            'name',
+        ), request
+
+    def test_problem_group_filter_returns_only_selected_group(self):
+        filter_instance, request = self.build_filter({'problem_group': str(self.algorithm_problem.group_id)})
+
+        queryset = filter_instance.queryset(request, Problem.objects.all())
+
+        self.assertQuerySetEqual(
+            queryset.order_by('code'),
+            [self.algorithm_problem],
+            transform=lambda problem: problem,
+        )
+
+    def test_problem_group_filter_ignores_unknown_group_value(self):
+        filter_instance, request = self.build_filter({'problem_group': '999999'})
+
+        queryset = filter_instance.queryset(request, Problem.objects.filter(
+            id__in=[self.algorithm_problem.id, self.contest_problem.id]
+        ))
+
+        self.assertCountEqual(
+            queryset.values_list('code', flat=True),
+            [self.algorithm_problem.code, self.contest_problem.code],
+        )
+
+    def test_problem_group_choices_are_grouped_by_parent_path(self):
+        create_problem(code='cpp001', group='교재별/C++ 프로그래밍/클래스 Part 1')
+        create_problem(code='cpp002', group='교재별/C++ 프로그래밍/템플릿')
+
+        filter_instance, _ = self.build_filter()
+        ungrouped, grouped = filter_instance.grouped_group_lookups
+
+        self.assertIn((str(self.algorithm_problem.group_id), 'algorithm'), ungrouped)
+        self.assertIn(
+            (
+                '교재별 / C++ 프로그래밍',
+                (
+                    (str(Problem.objects.get(code='cpp001').group_id), '클래스 Part 1'),
+                    (str(Problem.objects.get(code='cpp002').group_id), '템플릿'),
+                ),
+            ),
+            grouped,
+        )

--- a/site/templates/admin/input_filter/input_filter_problem.html
+++ b/site/templates/admin/input_filter/input_filter_problem.html
@@ -1,6 +1,6 @@
 <head>
-  <link 
-    rel="stylesheet" 
+  <link
+    rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
     crossorigin="anonymous"
@@ -8,7 +8,7 @@
 </head>
 <form method="get">
   {% for key, value in request.GET.items %}
-      {% if key != 'is_public' and key != 'encryption_status' and key != 'authors' and key != 'name' and key != 'code' %}
+      {% if key not in spec.filter_keys %}
       <input type="hidden" name="{{ key }}" value="{{ value }}">
       {% endif %}
   {% endfor %}
@@ -35,11 +35,31 @@
 <label>
   문제 코드
   <input type="text" name="code" value="{{ request.GET.code}}" placeholder="문제 코드">
-</label>  
+</label>
 <label>
   문제 이름
   <input type="text" name="name" value="{{ request.GET.name }}" placeholder="문제 이름">
-</label>  
+</label>
+<label>
+  문제 그룹
+  <select name="problem_group">
+    <option value="">전체</option>
+    {% for value, label in spec.grouped_group_lookups.0 %}
+      <option value="{{ value }}" {% if request.GET.problem_group == value %}selected{% endif %}>
+        {{ label }}
+      </option>
+    {% endfor %}
+    {% for parent_label, children in spec.grouped_group_lookups.1 %}
+      <optgroup label="{{ parent_label }}">
+        {% for value, label in children %}
+          <option value="{{ value }}" {% if request.GET.problem_group == value %}selected{% endif %}>
+            {{ label }}
+          </option>
+        {% endfor %}
+      </optgroup>
+    {% endfor %}
+  </select>
+</label>
   <button type="submit" style="font-size: 14px;">
   <i class="fa-solid fa-filter"></i> 필터 적용
 </button>


### PR DESCRIPTION
관리자 페이지의 문제 탭을 보면 원래 공개 여부, 암호화 여부, 출제자, 문제 코드, 문제 이름만으로 필터하여 문제를 확인했다면, 
여기서 문제 그룹을 추가하여 필터링이 가능하도록 수정하였습니다.

1. site/templates/admin/input_filter/input_filter_problem.html 에서
관리자 화면에 문제 그룹 선택칸을 만들었습니다.

2. 그 선택값이 problem_group이라는 이름으로 서버에 전달됩니다.

3. site/judge/admin/problem.py 의 ProblemCombinedInputFilter.queryset()에서
problem_group 값을 읽습니다.

4. 값이 있으면
queryset = queryset.filter(group_id=problem_group)
를 실행해서, 그 그룹에 속한 문제만 남깁니다.

<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/73dec8da-b4c1-4325-b158-9062fc23ca6f" />
