### PR TITLE
feat:Improve lightweight error pages

### DIFF
--- a/site/judge/views/error.py
+++ b/site/judge/views/error.py
@@ -1,19 +1,110 @@
 import traceback
 
+from django.http import HttpResponse, HttpResponseNotFound
 from django.shortcuts import render
+from django.template.loader import render_to_string
+from django.urls import Resolver404
 from django.utils.translation import gettext as _
 
 
+BOT_USER_AGENT_MARKERS = (
+    'bot',
+    'crawler',
+    'spider',
+    'slurp',
+    'baiduspider',
+    'yandex',
+    'duckduckbot',
+)
+
+LIGHTWEIGHT_404_PREFIXES = (
+    '/api/',
+    '/static/',
+    '/media/',
+)
+
+LIGHTWEIGHT_404_PATHS = (
+    '/favicon.ico',
+    '/robots.txt',
+    '/sitemap.xml',
+    '/manifest.json',
+)
+
+
 def error(request, context, status):
-    return render(request, 'error.html', context=context, status=status)
+    context = dict(context)
+    context.update({
+        'csp_nonce': getattr(request, 'csp_nonce', ''),
+        'language_code': getattr(request, 'LANGUAGE_CODE', 'ko'),
+        'show_traceback': getattr(getattr(request, 'user', None), 'is_superuser', False),
+    })
+    content = render_to_string('error.html', context=context)
+    return HttpResponse(content, status=status, content_type='text/html; charset=utf-8')
+
+
+def _accepts_html_page(request):
+    accept = request.META.get('HTTP_ACCEPT', '')
+    if not accept:
+        return False
+
+    accepted_types = [item.split(';', 1)[0].strip().lower() for item in accept.split(',')]
+    return 'text/html' in accepted_types or 'application/xhtml+xml' in accepted_types
+
+
+def _is_json_or_ajax_request(request):
+    if request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
+        return True
+
+    accept = request.META.get('HTTP_ACCEPT', '').lower()
+    return 'application/json' in accept or '+json' in accept
+
+
+def _is_bot_request(request):
+    user_agent = request.META.get('HTTP_USER_AGENT', '').lower()
+    return any(marker in user_agent for marker in BOT_USER_AGENT_MARKERS)
+
+
+def _is_lightweight_404_path(request):
+    path = request.path_info or request.path
+    return path in LIGHTWEIGHT_404_PATHS or path.startswith(LIGHTWEIGHT_404_PREFIXES)
+
+
+def _should_render_browser_404_redirect(request, exception):
+    return (
+        isinstance(exception, Resolver404) and
+        _accepts_html_page(request) and
+        not _is_json_or_ajax_request(request) and
+        not _is_bot_request(request) and
+        not _is_lightweight_404_path(request)
+    )
+
+
+def _should_render_browser_404_message(request):
+    return (
+        _accepts_html_page(request) and
+        not _is_json_or_ajax_request(request) and
+        not _is_bot_request(request) and
+        not _is_lightweight_404_path(request)
+    )
 
 
 def error404(request, exception=None):
-    # TODO: "panic: go back"
-    return render(request, 'generic-message.html', {
-        'title': _('404 error'),
-        'message': _('Could not find page "%s"') % request.path,
-    }, status=404)
+    if _should_render_browser_404_message(request):
+        should_redirect_home = _should_render_browser_404_redirect(request, exception)
+        content = render_to_string('404-redirect-home.html', {
+            'auto_redirect_home': should_redirect_home,
+            'csp_nonce': getattr(request, 'csp_nonce', ''),
+            'language_code': getattr(request, 'LANGUAGE_CODE', 'ko'),
+            'title': _('Page not found'),
+            'message': (
+                _('You will be redirected to the home page shortly.')
+                if should_redirect_home else
+                _('The requested page or result does not exist.')
+            ),
+        })
+        return HttpResponseNotFound(content, content_type='text/html; charset=utf-8')
+
+    return HttpResponseNotFound('Not Found\n', content_type='text/plain; charset=utf-8')
 
 
 def error403(request, exception=None):

--- a/site/templates/404-redirect-home.html
+++ b/site/templates/404-redirect-home.html
@@ -4,20 +4,26 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex">
-    <title>{{ code }} - Litmus</title>
-    <script{% if csp_nonce %} nonce="{{ csp_nonce }}"{% endif %}>
-        document.addEventListener('DOMContentLoaded', function () {
-            var backButton = document.getElementById('back-button');
-            if (!backButton) return;
-            backButton.addEventListener('click', function () {
-                if (window.history.length > 1) {
-                    window.history.back();
-                } else {
-                    window.location.href = '/';
-                }
+    <title>{{ title }} - Litmus</title>
+    {% if auto_redirect_home %}
+        <script{% if csp_nonce %} nonce="{{ csp_nonce }}"{% endif %}>
+            window.location.replace('/');
+        </script>
+    {% else %}
+        <script{% if csp_nonce %} nonce="{{ csp_nonce }}"{% endif %}>
+            document.addEventListener('DOMContentLoaded', function () {
+                var backButton = document.getElementById('back-button');
+                if (!backButton) return;
+                backButton.addEventListener('click', function () {
+                    if (window.history.length > 1) {
+                        window.history.back();
+                    } else {
+                        window.location.href = '/';
+                    }
+                });
             });
-        });
-    </script>
+        </script>
+    {% endif %}
     <style>
         :root {
             color-scheme: light;
@@ -26,7 +32,6 @@
             --litmus-muted: #5f6368;
             --litmus-line: #e4e7eb;
             --litmus-bg: #f8fafc;
-            --litmus-danger: #b42318;
         }
 
         * {
@@ -52,7 +57,7 @@
         }
 
         main {
-            width: min(100%, 460px);
+            width: min(100%, 420px);
             border: 1px solid var(--litmus-line);
             border-top: 4px solid var(--litmus-accent);
             border-radius: 8px;
@@ -65,14 +70,6 @@
             margin: 0 0 18px;
             color: var(--litmus-ink);
             font-size: 18px;
-            font-weight: 700;
-            letter-spacing: 0;
-        }
-
-        .code {
-            margin: 0 0 8px;
-            color: var(--litmus-danger);
-            font-size: 14px;
             font-weight: 700;
             letter-spacing: 0;
         }
@@ -123,56 +120,30 @@
         }
 
         button:focus,
-        a:focus,
-        summary:focus {
+        a:focus {
             outline: 3px solid rgba(82, 133, 196, 0.35);
             outline-offset: 2px;
-        }
-
-        details {
-            margin-top: 22px;
-            border-top: 1px solid var(--litmus-line);
-            padding-top: 16px;
-        }
-
-        summary {
-            color: var(--litmus-muted);
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: 700;
-        }
-
-        pre {
-            overflow: auto;
-            max-height: 320px;
-            margin: 12px 0 0;
-            border-radius: 6px;
-            background: #111827;
-            color: #f9fafb;
-            padding: 14px;
-            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-            font-size: 12px;
-            line-height: 1.45;
-            white-space: pre-wrap;
         }
     </style>
 </head>
 <body>
     <main>
         <p class="brand">Litmus</p>
-        <p class="code">{{ code }} error</p>
-        <h1>요청을 처리하지 못했습니다.</h1>
-        <p>{{ description|default('일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.') }}</p>
+        <h1>페이지를 찾을 수 없습니다.</h1>
+        <p>{{ message }}</p>
+        {% if auto_redirect_home %}
+            <noscript>
+                <p>JavaScript가 꺼져 있으면 아래 버튼을 눌러 홈으로 이동하세요.</p>
+            </noscript>
+        {% endif %}
         <div class="actions">
-            <button id="back-button" type="button">이전 페이지로 돌아가기</button>
+            {% if not auto_redirect_home %}
+                <button id="back-button" type="button">
+                    이전 페이지로 돌아가기
+                </button>
+            {% endif %}
             <a href="/">홈으로 이동</a>
         </div>
-        {% if show_traceback and traceback %}
-            <details>
-                <summary>오류 상세 정보</summary>
-                <pre>{{ traceback }}</pre>
-            </details>
-        {% endif %}
     </main>
 </body>
 </html>


### PR DESCRIPTION
  - 브라우저 요청용 404 페이지를 추가했습니다.
  - 존재하지 않는 URL은 JS로 `/` 홈으로 이동하게 했습니다.
  - 쿼리 요청의 404는 홈으로 이동하지 않고 오류 페이지에서 이전 페이지와 홈 이동 버튼
  - API/정적 파일/JSON/AJAX/봇성 요청은 렌더링 없이 가벼운 Not Found 응답을 유지했습니다.
  - 기존 403/500의 SIGSEGV, Segmentation fault, site died 화면을 Litmus 톤 오류 페이지로 교체했습니다.
  - 403/500 오류 페이지가 전체 context processor를 타지 않도록 변경해, 오류 페이지 렌더링 중 DB 조회로 다시 실패하는 문제를 줄였습니다.
  
  
<img width="1092" height="730" alt="image" src="https://github.com/user-attachments/assets/d22bd4e2-3488-4d93-941b-267e99aab1a5" />

