### PR TITLE
fix: 로그인 잠금 안내 표시 위치 조정

### DIFF
--- a/site/templates/registration/login-admin.html
+++ b/site/templates/registration/login-admin.html
@@ -149,15 +149,10 @@
     }
 
     .login-lock-notice {
-        display: block;
-        align-self: stretch;
-        width: 100%;
-        max-width: 100%;
-        margin: -4px 0 4px;
+        margin: 4px 0 0;
         font-size: 14px;
         font-weight: 400;
-        color: #222;
-        text-align: center;
+        color: inherit;
         white-space: pre-line;
     }
 
@@ -174,6 +169,10 @@
         color: #D64545;
     }
 
+    #form-errors.invalid_login {
+        padding-bottom: 0.75em;
+    }
+
     #form-errors.invalid_login .error {
         white-space: pre-line;
     }
@@ -185,9 +184,6 @@
     <h2>관리자 로그인</h2>
     <form action="" method="post" class="form-area">
         {% csrf_token %}
-        <div class="login-lock-notice">
-            {{ form.login_lock_notice_message }}
-        </div>
         {% if form.errors %}
             {% for field, errors in form.errors.items() %}
                 {% for error in errors %}
@@ -203,6 +199,9 @@
                     {% else %}
                         <div id="form-errors" class="invalid_login">
                             <p class="error">{{ error }}</p>
+                            {% if error == form.error_messages.invalid_login %}
+                            <p class="login-lock-notice">{{ form.login_lock_notice_message }}</p>
+                            {% endif %}
                         </div>
                     {% endif %}
                 {% endfor %}

--- a/site/templates/registration/login.html
+++ b/site/templates/registration/login.html
@@ -232,15 +232,10 @@
     }
 
     .login-lock-notice {
-        display: block;
-        align-self: stretch;
-        width: 100%;
-        max-width: 100%;
-        margin: -4px 0 4px;
+        margin: 4px 0 0;
         font-size: 14px;
         font-weight: 400;
-        color: var(--font-basic-black);
-        text-align: center;
+        color: inherit;
         white-space: pre-line;
     }
 
@@ -255,6 +250,10 @@
     #form-errors.invalid_login,
     #form-errors.invalid_login .error {
         color: #D64545;
+    }
+
+    #form-errors.invalid_login {
+        padding-bottom: 0.75em;
     }
 
     #form-errors.invalid_login .error {
@@ -282,9 +281,6 @@
     <form action="" method="post" class="form-area">
         {% csrf_token %}
 
-        <div class="login-lock-notice">
-            {{ form.login_lock_notice_message }}
-        </div>
         <!-- 관리자 로그인 -->
         {% if form.errors %}
             {% for field, errors in form.errors.items() %}
@@ -301,6 +297,9 @@
                     {% else %}
                     <div id="form-errors" class="invalid_login">
                         <p class="error">{{ error }}</p>
+                        {% if error == form.error_messages.invalid_login %}
+                        <p class="login-lock-notice">{{ form.login_lock_notice_message }}</p>
+                        {% endif %}
                     </div>
                     {% endif %}
                 {% endfor %}


### PR DESCRIPTION
## 로그인 실패 시 잠금 안내 문구 표시 위치를 조정했습니다.

- 기존에는 로그인 화면 진입 시점부터 “아이디 또는 비밀번호를 5회 이상 잘못 입력하면 10분 동안 로그인이 잠깁니다.” 문구가 항상 표시

-> 로그인 버튼을 누른 뒤 아이디 또는 비밀번호가 잘못된 경우에만, 빨간 오류 박스 안에서 “아이디 또는 비밀번호가 잘못되었습니다.” 문구 아래에 이어서 표시되도록 수정

## 로그인 시도 전
<img width="1005" height="644" alt="image" src="https://github.com/user-attachments/assets/bb6e0b14-963c-43d3-930f-a50649851fce" />

## 로그인 시도 후
<img width="1091" height="798" alt="image" src="https://github.com/user-attachments/assets/4aa56211-0ad8-424b-b7fd-4744dac866d4" />
