### PR TITLE
feat: 관리자 로그인 잠금 해제 액션 추가

### DIFF
--- a/site/judge/admin/profile.py
+++ b/site/judge/admin/profile.py
@@ -193,7 +193,7 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
     list_filter = [
         ('id', CombinedProfileFilter),
     ]
-    actions = ('recalculate_points',)
+    actions = ('recalculate_points', 'clear_login_lock')
     actions_on_top = True
     actions_on_bottom = True
     form = ProfileForm
@@ -294,6 +294,16 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
                                             '%d users had scores recalculated.',
                                             count) % count)
     recalculate_points.short_description = _('Recalculate scores')
+
+    def clear_login_lock(self, request, queryset):
+        count = 0
+        for profile in queryset:
+            profile.clear_login_failures()
+            count += 1
+        self.message_user(request, ngettext('%d user had login lock cleared.',
+                                            '%d users had login locks cleared.',
+                                            count) % count)
+    clear_login_lock.short_description = _('10분 로그인 잠금 해제')
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(ProfileAdmin, self).get_form(request, obj, **kwargs)


### PR DESCRIPTION
- 관리자 페이지에 10분 로그인 잠금 해제 액션을 추가했습니다.

-  사용자가 아이디 또는 비밀번호를 5회 이상 잘못 입력해 로그인 잠금 상태가 된 경우, 관리자가 Profile 목록에서 해당 사용자를 선택해 잠금을 즉시 해제할 수 있도록 했습니다.
<img width="1742" height="750" alt="image" src="https://github.com/user-attachments/assets/94787ba7-f482-4024-aa51-bfe9ffaf9192" />
