### PR TITLE
fix: page=2쿼리 삭제

### DIFF
--- a/site/templates/problem/list.html
+++ b/site/templates/problem/list.html
@@ -451,6 +451,7 @@
 
                     const url = new URL(window.location.href);
                     url.searchParams.delete('groupId');
+                    url.searchParams.delete('page');
                     if (groupId != 'all'){
                         url.searchParams.append('groupId', groupId);
                     }


### PR DESCRIPTION
# 수정 전
- #### 기존 탭에서 1페이지 외에 다른 페이지로 접근 후 바로 다른 탭으로 변경 시 page 쿼리가 지워지지 않아서 오류 발생
<img width="1191" height="897" alt="image" src="https://github.com/user-attachments/assets/d6620750-e801-4367-a9eb-fefd9be6b035" />
<img width="1918" height="976" alt="image" src="https://github.com/user-attachments/assets/405f7744-3955-4dd7-aa29-3f1ba10649f6" />

# 수정 후
- #### 탭 변경 시 page 쿼리 지움 -> 다른 탭들도 다 적용됨
<img width="1133" height="911" alt="image" src="https://github.com/user-attachments/assets/48b79955-6796-4379-aaa6-336266ec12b5" />
<img width="1917" height="968" alt="image" src="https://github.com/user-attachments/assets/0580de48-bdef-472d-af38-b16d62788e5b" />
