### PR TITLE
fix: 비활성 계정 로그인 흐름 수정

### DIFF
--- a/site/judge/views/user.py
+++ b/site/judge/views/user.py
@@ -167,7 +167,21 @@ class UserPage(TitleMixin, UserMixin, DetailView):
 #             self.request.session['password_pwned'] = False
 #         return super().form_valid(form)
 
-class CustomLoginView(LoginView):
+class InactiveAccountRedirectMixin:
+    def form_invalid(self, form):
+        if self._has_inactive_error(form):
+            return HttpResponseRedirect(reverse('activation_required'))
+        return super().form_invalid(form)
+
+    def _has_inactive_error(self, form):
+        return any(
+            error.code == 'inactive'
+            for errors in form.errors.as_data().values()
+            for error in errors
+        )
+
+
+class CustomLoginView(InactiveAccountRedirectMixin, LoginView):
     template_name = 'registration/login.html'
     extra_context = {'title': gettext_lazy('Login')}
     authentication_form = CustomAuthenticationForm
@@ -185,7 +199,7 @@ class CustomLoginView(LoginView):
         return super().form_valid(form)
 
 # 관리자 로그인 추가 
-class AdminLoginView(LoginView):
+class AdminLoginView(InactiveAccountRedirectMixin, LoginView):
     template_name = 'registration/login-admin.html'
     extra_context = {'title': gettext_lazy('Login')}
     authentication_form = CustomAuthenticationForm
@@ -681,7 +695,17 @@ class IdFindCompleteView(TemplateView):
 
 # 이메일 변경 클래스 (활성화가 되지 않은 계정)   
 User = get_user_model()
-class EmailChangeView(FormView):
+class AdminOnlyMixin:
+    def dispatch(self, request, *args, **kwargs):
+        if not (
+            request.user.is_authenticated and
+            (request.user.is_staff or request.user.is_superuser)
+        ):
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+
+class EmailChangeView(AdminOnlyMixin, FormView):
     title = _('이메일 변경')
     form_class = EmailChangeForm
     template_name = 'registration/email_change.html'  
@@ -719,7 +743,7 @@ class EmailChangeView(FormView):
         return super().form_valid(form)
 
 # 이메일 변경 완료 클래스 (활성화가 되지 않은 계정)  
-class EmailChangeCompleteView(TemplateView):
+class EmailChangeCompleteView(AdminOnlyMixin, TemplateView):
     template_name = 'registration/email_change_complete.html'
     title = _('이메일 변경 완료')
 

--- a/site/templates/registration/activation_required.html
+++ b/site/templates/registration/activation_required.html
@@ -61,7 +61,6 @@
         </p>
         <div class="message-links">
             <a href="{{ url('resend_activation_email') }}">{{ _('활성화 메일 재전송') }}</a>
-            <a href="{{ url('email_change') }}">{{ _('이메일 변경') }}</a>
         </div>
     </div>
 {% endblock %}

--- a/site/templates/registration/login-admin.html
+++ b/site/templates/registration/login-admin.html
@@ -187,23 +187,12 @@
         {% if form.errors %}
             {% for field, errors in form.errors.items() %}
                 {% for error in errors %}
-                    {% if error == form.error_messages.inactive %}
-                        <div id="form-errors" class="inactive">
-                            <p class="error">{{ error }}</p>
-                            <p>도움이 필요하신가요?</p>
-                            <p>
-                                <a href="{{ url('email_change') }}">이메일 변경</a> |
-                                <a href="{{ url('resend_activation_email') }}">활성화 메일 재전송</a>
-                            </p>
-                        </div>
-                    {% else %}
-                        <div id="form-errors" class="invalid_login">
-                            <p class="error">{{ error }}</p>
-                            {% if error == form.error_messages.invalid_login %}
-                            <p class="login-lock-notice">{{ form.login_lock_notice_message }}</p>
-                            {% endif %}
-                        </div>
-                    {% endif %}
+                    <div id="form-errors" class="invalid_login">
+                        <p class="error">{{ error }}</p>
+                        {% if error == form.error_messages.invalid_login %}
+                        <p class="login-lock-notice">{{ form.login_lock_notice_message }}</p>
+                        {% endif %}
+                    </div>
                 {% endfor %}
             {% endfor %}
         {% endif %}

--- a/site/templates/registration/login.html
+++ b/site/templates/registration/login.html
@@ -281,27 +281,15 @@
     <form action="" method="post" class="form-area">
         {% csrf_token %}
 
-        <!-- 관리자 로그인 -->
         {% if form.errors %}
             {% for field, errors in form.errors.items() %}
                 {% for error in errors %}
-                    {% if error == form.error_messages.inactive %}
-                    <div id="form-errors" class="inactive">
-                        <p class="error">{{ error }}</p>
-                        <p>도움이 필요하신가요?</p>
-                        <p>
-                            <a href="{{ url('email_change') }}">이메일 변경</a> |
-                            <a href="{{ url('resend_activation_email') }}">활성화 메일 재전송</a>
-                        </p>
-                    </div>
-                    {% else %}
                     <div id="form-errors" class="invalid_login">
                         <p class="error">{{ error }}</p>
                         {% if error == form.error_messages.invalid_login %}
                         <p class="login-lock-notice">{{ form.login_lock_notice_message }}</p>
                         {% endif %}
                     </div>
-                    {% endif %}
                 {% endfor %}
             {% endfor %}
         {% endif %}


### PR DESCRIPTION
# 1. 비활성화 계정으로 로그인
- ### 비활성화 계정으로 로그인 시 주황 박스로 알림창을 띄우는 대신 /activation/required/로 리다이렉팅 되게 변경
## 수정 전
<img width="578" height="714" alt="image" src="https://github.com/user-attachments/assets/3b89d8bd-67a6-4906-8cfb-9f28b0bd8821" />

## 수정 후
<img width="837" height="560" alt="image" src="https://github.com/user-attachments/assets/4e2ba9ee-5a02-4b8e-8bcc-0d60f62b1cd7" />

# 2. 비활성화 계정으로 로그인
- ### 이메일 변경 버튼 제거
## 수정 전
<img width="788" height="432" alt="image" src="https://github.com/user-attachments/assets/65e0826a-6ddf-443b-8cbc-a51324d6992a" />

## 수정 후
<img width="776" height="432" alt="image" src="https://github.com/user-attachments/assets/e8ff77a4-e569-4674-874b-e6e0cb7ca12d" />


# 3. 이메일 변경 관련
- ### 사용자가 이메일 변경 url에 접근 시 404 오류창을 띄움 + 관리자만 이메일 변경에 접근 가능하게 만듦
## 사용자가 이메일 변경 url 접근 시
<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/6921fb98-171c-4f7f-8a88-c779e2275fb5" />

## 관리자가 이메일 변경 url 접근 시
<img width="1918" height="928" alt="image" src="https://github.com/user-attachments/assets/3e3c8330-95af-4428-8171-50e081ebaa6b" />
