### PR TITLE
fix: 계정 메일 로고를 리트머스로 변경

### DIFF
--- a/site/templates/registration/activation_email.html
+++ b/site/templates/registration/activation_email.html
@@ -1,8 +1,8 @@
-<div style="border:2px solid #fd0;margin:4px 0;">
-    <div style="background:#000;border:6px solid #000;">
+<div style="border:1px solid #d8e7f8;border-left:6px solid #5c95d9;margin:4px 0;background:#f7fbff;">
+    <div style="background:#f7fbff;padding:16px 18px;">
         <a href="{{ request.scheme }}://{{ site.domain }}"><img
-                src="{{ request.scheme }}://{{ site.domain }}/static/icons/logo.svg" alt="{{ SITE_NAME }}" width="160"
-                height="44"></a>
+                src="{{ request.scheme }}://{{ site.domain }}/static/icons/Litmuslogo.png" alt="{{ SITE_NAME }}"
+                width="160" height="60" style="display:block;border:0;"></a>
     </div>
 </div>
 

--- a/site/templates/registration/password_reset_email.html
+++ b/site/templates/registration/password_reset_email.html
@@ -1,5 +1,5 @@
-<div style="border:2px solid #fd0;margin:4px 0;"><div style="background:#000;border:6px solid #000;">
-<a href="{{ protocol }}://{{ domain }}"><img src="{{ protocol }}://{{ domain }}/static/icons/logo.svg" alt="{{ site_name }}" width="160" height="44"></a>
+<div style="border:1px solid #d8e7f8;border-left:6px solid #5c95d9;margin:4px 0;background:#f7fbff;"><div style="background:#f7fbff;padding:16px 18px;">
+<a href="{{ protocol }}://{{ domain }}"><img src="{{ protocol }}://{{ domain }}/static/icons/Litmuslogo.png" alt="{{ site_name }}" width="160" height="60" style="display:block;border:0;"></a>
 </div></div>
 
 <div style="border:2px solid #337ab7;margin:4px 0;"><div style="background:#fafafa;border:12px solid #fafafa;font-family:segoe ui,lucida grande,Arial,sans-serif;font-size:14px;">


### PR DESCRIPTION
# 이메일 인증 시 dmoj 로고 표시 수정
- ### 이메일 변경 + 비밀번호 변경 시 이메일 인증 로고를 dmoj 로고 -> 리트머스 로고로 변경
## 수정 전
<img width="1425" height="530" alt="image" src="https://github.com/user-attachments/assets/852e3782-e004-469b-96b4-20047690f1d7" />

## 수정 후
<img width="1427" height="582" alt="image" src="https://github.com/user-attachments/assets/4a101ba0-1ff3-4246-8269-fadb17bd8b1c" />
