### PR TITLE
Jeong gu/external school jbedu email

### DIFF
--- a/site/judge/custom_pipeline.py
+++ b/site/judge/custom_pipeline.py
@@ -9,7 +9,7 @@ def assign_school_on_keycloak_login(backend, details, user, *args, **kwargs):
     - 리트머스 계정 없음(user=None) → 회원가입 리다이렉트
     - 이메일 미인증(is_active=False) → 로그인 페이지로 리다이렉트 (안내 메시지 포함)
     - @jbnu.ac.kr → is_jbnu=True인 School 자동 할당 (school이 아직 없는 경우만)
-    - @gmail.com → school은 가입 시 이미 설정됨, 파이프라인에서 변경하지 않음
+    - 외부 학교 이메일 → school은 가입 시 이미 설정됨, 파이프라인에서 변경하지 않음
     """
     if user is None:
         request = backend.strategy.request

--- a/site/judge/models/profile.py
+++ b/site/judge/models/profile.py
@@ -180,7 +180,7 @@ class School(models.Model):
     short_name = models.CharField(max_length=20, verbose_name='약칭')
     school_type = models.CharField(max_length=20, choices=SCHOOL_TYPES)
     is_jbnu = models.BooleanField(default=False, verbose_name='전북대 여부',
-                                  help_text='True이면 @jbnu.ac.kr 이메일 강제, False이면 @gmail.com 강제')
+                                  help_text='True이면 @jbnu.ac.kr 이메일 강제, False이면 @g.jbedu.kr 강제')
     is_active = models.BooleanField(default=True)
 
     def __str__(self):

--- a/site/judge/models/tests/test_registration_email_domains.py
+++ b/site/judge/models/tests/test_registration_email_domains.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from judge.views.register import (
+    EXTERNAL_SCHOOL_EMAIL_DOMAIN,
+    JBNU_EMAIL_DOMAIN,
+    _build_registration_email,
+)
+
+
+class RegistrationEmailDomainTestCase(SimpleTestCase):
+    def test_jbnu_school_uses_jbnu_domain(self):
+        email, errors = _build_registration_email(
+            SimpleNamespace(is_jbnu=True),
+            '202400001',
+            JBNU_EMAIL_DOMAIN,
+        )
+
+        self.assertEqual(email, '202400001@jbnu.ac.kr')
+        self.assertEqual(errors, [])
+
+    def test_external_school_uses_jbedu_domain(self):
+        email, errors = _build_registration_email(
+            SimpleNamespace(is_jbnu=False),
+            'student',
+            EXTERNAL_SCHOOL_EMAIL_DOMAIN,
+        )
+
+        self.assertEqual(email, 'student@g.jbedu.kr')
+        self.assertEqual(errors, [])
+
+    def test_external_school_rejects_gmail_for_new_registration(self):
+        email, errors = _build_registration_email(
+            SimpleNamespace(is_jbnu=False),
+            'student',
+            '@gmail.com',
+        )
+
+        self.assertEqual(email, 'student@g.jbedu.kr')
+        self.assertEqual(errors, ['외부 학교는 @g.jbedu.kr 이메일만 사용 가능합니다.'])
+
+    def test_missing_domain_still_builds_expected_external_email(self):
+        email, errors = _build_registration_email(
+            SimpleNamespace(is_jbnu=False),
+            'student',
+            '',
+        )
+
+        self.assertEqual(email, 'student@g.jbedu.kr')
+        self.assertEqual(errors, [])

--- a/site/judge/views/register.py
+++ b/site/judge/views/register.py
@@ -31,6 +31,9 @@ from judge.widgets import Select2MultipleWidget, Select2Widget
 
 bad_mail_regex = list(map(re.compile, settings.BAD_MAIL_PROVIDER_REGEX))
 
+JBNU_EMAIL_DOMAIN = '@jbnu.ac.kr'
+EXTERNAL_SCHOOL_EMAIL_DOMAIN = '@g.jbedu.kr'
+
 
 def _current_registration_student_year():
     now = timezone.now()
@@ -50,14 +53,16 @@ def _build_registration_email(school, email_local, email_domain):
     if not email_local:
         return '', []
 
-    expected_domain = '@jbnu.ac.kr' if school and school.is_jbnu else '@gmail.com'
+    expected_domain = JBNU_EMAIL_DOMAIN if school and school.is_jbnu else EXTERNAL_SCHOOL_EMAIL_DOMAIN
     errors = []
 
     if email_domain and email_domain != expected_domain:
-        if expected_domain == '@jbnu.ac.kr':
-            errors.append(gettext('전북대학교는 @jbnu.ac.kr 이메일만 사용 가능합니다.'))
+        if expected_domain == JBNU_EMAIL_DOMAIN:
+            errors.append(gettext('전북대학교는 %(domain)s 이메일만 사용 가능합니다.') % {'domain': JBNU_EMAIL_DOMAIN})
         else:
-            errors.append(gettext('외부 학교는 Gmail(@gmail.com)만 사용 가능합니다.'))
+            errors.append(gettext('외부 학교는 %(domain)s 이메일만 사용 가능합니다.') % {
+                'domain': EXTERNAL_SCHOOL_EMAIL_DOMAIN,
+            })
 
     return f'{email_local}{expected_domain}', errors
 
@@ -311,15 +316,19 @@ class CustomRegistrationForm(RegistrationForm):
         email_domain = cleaned_data.get('email_domain')
 
         if school and school.is_jbnu:
-            email = f"{email_local}@jbnu.ac.kr"
-            if email_domain != '@jbnu.ac.kr':
+            email = f"{email_local}{JBNU_EMAIL_DOMAIN}"
+            if email_domain != JBNU_EMAIL_DOMAIN:
                 raise forms.ValidationError(
-                    gettext('전북대학교는 @jbnu.ac.kr 이메일만 사용 가능합니다.'), code='email')
+                    gettext('전북대학교는 %(domain)s 이메일만 사용 가능합니다.') % {
+                        'domain': JBNU_EMAIL_DOMAIN,
+                    }, code='email')
         else:
-            email = f"{email_local}@gmail.com"
-            if email_domain != '@gmail.com':
+            email = f"{email_local}{EXTERNAL_SCHOOL_EMAIL_DOMAIN}"
+            if email_domain != EXTERNAL_SCHOOL_EMAIL_DOMAIN:
                 raise forms.ValidationError(
-                    gettext('외부 학교는 Gmail(@gmail.com)만 사용 가능합니다.'), code='email')
+                    gettext('외부 학교는 %(domain)s 이메일만 사용 가능합니다.') % {
+                        'domain': EXTERNAL_SCHOOL_EMAIL_DOMAIN,
+                    }, code='email')
 
         cleaned_data['email'] = email
 
@@ -379,6 +388,8 @@ class RegistrationView(OldRegistrationView):
         kwargs['validate_registration_url'] = reverse('validate_registration')
         jbnu = School.objects.filter(is_jbnu=True).first()
         kwargs['jbnu_school_id'] = jbnu.id if jbnu else ''
+        kwargs['jbnu_email_domain'] = JBNU_EMAIL_DOMAIN
+        kwargs['external_school_email_domain'] = EXTERNAL_SCHOOL_EMAIL_DOMAIN
         return super(RegistrationView, self).get_context_data(**kwargs)
 
     def register(self, form):

--- a/site/templates/registration/registration_form.html
+++ b/site/templates/registration/registration_form.html
@@ -516,7 +516,7 @@
             var jbnuSchoolId = '{{ jbnu_school_id }}';
             $('#id_school').on('change', function() {
                 var isJbnu = (String(this.value) === String(jbnuSchoolId));
-                var domain = isJbnu ? '@jbnu.ac.kr' : '@gmail.com';
+                var domain = isJbnu ? '{{ jbnu_email_domain }}' : '{{ external_school_email_domain }}';
                 $('span.email_domain').text(domain);
                 $('input[name=email_domain]').val(domain);
                 document.querySelector('#id_email_local').dispatchEvent(new Event('input', { bubbles: true }));


### PR DESCRIPTION
  ## Changes
  - 전북대 계정은 기존처럼 `@jbnu.ac.kr`을 사용합니다.
  - 전북대 외 학교 계정은 신규 가입 시 `@g.jbedu.kr`을 사용합니다.
    - 신규 외부 학교 회원가입 이메일 도메인을 `@gmail.com`에서 `@g.jbedu.kr`로 변경했습니다.
  - 기존 `@gmail.com` 계정과 Keycloak 연결은 변경하지 않아 기존 사용자는 그대로 사용할 수 있습니다.