### PR TITLE
chore: .env.example 설정 동기화

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -33,6 +33,7 @@ EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 EMAIL_HOST=smtp.your-domain.com
 EMAIL_PORT=587
 EMAIL_USE_TLS=True
+EMAIL_USE_SSL=False
 EMAIL_HOST_USER=your-email@your-domain.com
 EMAIL_HOST_PASSWORD=your-email-password
 
@@ -70,6 +71,7 @@ SOCIAL_AUTH_KEYCLOAK_ALGORITHM=RS256
 # 추가 인증 설정
 SOCIAL_AUTH_KEYCLOAK_EXTRA_ARGUMENTS={"scope": "openid profile email"}
 SOCIAL_AUTH_JWT_AUDIENCE=your-client-id
+SOCIAL_AUTH_KEYCLOAK_ID_KEY=email
 
 #####################################
 ########## 주의사항 #################


### PR DESCRIPTION
## 변경 사항

  - `.env.example`에 `EMAIL_USE_SSL` 예시 값을 추가했습니다.
  - Django 설정에서 필수로 읽는 `SOCIAL_AUTH_KEYCLOAK_ID_KEY`를 `.env.example`에 추가했습니다.
  - `.env.example`의 환경변수 목록을 실제 사용 중인 `.env`와 일치시켰습니다.