### PR TITLE
feature: 이메일 변경 도메인 자동 판별 기능 추가

### DIFF
--- a/site/dmoj/urls.py
+++ b/site/dmoj/urls.py
@@ -65,6 +65,7 @@ register_patterns = [
     # 이메일 변경 기능 라우팅
     path('email/change/', user.EmailChangeView.as_view(), name='email_change'),
     path('email/change/complete/', user.EmailChangeCompleteView.as_view(), name='email_change_complete'),
+    path('email/change/domain/', user.email_change_domain_lookup, name='email_change_domain_lookup'),
 
     # 이메일 인증 필요 안내 페이지
     path('activation/required/',

--- a/site/judge/forms.py
+++ b/site/judge/forms.py
@@ -556,6 +556,17 @@ class CustomPasswordResetForm(PasswordResetForm):
         return cleaned_data
 
 # 이메일 변경 관련 폼
+# 도메인은 회원가입 때와 동일한 기준(judge/views/register.py 참고)을 사용:
+# 전북대(is_jbnu=True) 소속이면 jbnu.ac.kr, 그 외(외부 학교)는 g.jbedu.kr
+JBNU_EMAIL_DOMAIN = '@jbnu.ac.kr'
+EXTERNAL_SCHOOL_EMAIL_DOMAIN = '@g.jbedu.kr'
+
+
+def get_email_domain_for_user(user):
+    school = getattr(getattr(user, 'profile', None), 'school', None)
+    return JBNU_EMAIL_DOMAIN if school and school.is_jbnu else EXTERNAL_SCHOOL_EMAIL_DOMAIN
+
+
 class EmailChangeForm(forms.Form):
     error_messages = {
         'invalid_login': "아이디 또는 비밀번호가 잘못되었습니다.",
@@ -598,20 +609,23 @@ class EmailChangeForm(forms.Form):
         username = self.cleaned_data.get('username')
         password = self.cleaned_data.get('password')
         email_local = self.cleaned_data.get('email_local')
-        email_domain = cleaned_data.get('email_domain')
 
-        # 이메일 주소 재구성
-        email = f"{email_local}@jbnu.ac.kr"
-        
-        # email_domain이 올바른 도메인인지 확인
-        if email_domain != "@jbnu.ac.kr":
-            raise forms.ValidationError(_('유효하지 않은 이메일 도메인입니다. (jbnu.ac.kr의 도메인 필수)'), code='email')
+        # username으로 대상 계정을 찾아 소속 학교에 맞는 도메인을 결정한다.
+        # (전북대 소속이면 jbnu.ac.kr, 외부 학교면 g.jbedu.kr)
+        target_user = User.objects.filter(username=username).first() if username else None
+        expected_domain = get_email_domain_for_user(target_user)
+
+        # 이메일 주소 재구성 (프론트에서 전달한 email_domain은 표시용일 뿐,
+        # 실제 도메인은 항상 서버에서 계정 정보 기준으로 재계산한다)
+        email = f"{email_local}{expected_domain}" if email_local else ''
+        cleaned_data['email'] = email
+        cleaned_data['target_user'] = target_user
 
         if username is not None and password:
             for backend_path in settings.AUTHENTICATION_BACKENDS:
                 backend = self._get_backend(backend_path)
                 if backend:
-                    user = self._try_login_with_backend(backend, username, password)
+                    user = self._try_login_with_backend(backend, target_user, password)
                     if user:
                         if user.is_active:  # 계정이 이미 활성화 된 경우
                             raise forms.ValidationError(_('이미 활성화된 계정입니다.'), code='active_user')
@@ -620,12 +634,11 @@ class EmailChangeForm(forms.Form):
             else:  # 아이디, 비밀번호에 맞는 계정이 존재하지 않는 경우
                 raise forms.ValidationError(_('아이디 또는 비밀번호가 잘못되었습니다.'), code='invalid_login')
 
-        if User.objects.filter(email=email).exists():  # 이미 존재하는 이메일의 경우
+        if email and User.objects.filter(email=email).exists():  # 이미 존재하는 이메일의 경우
             raise forms.ValidationError(_('이미 존재하는 이메일입니다.'), code='exists_email')
 
-        return self.cleaned_data
+        return cleaned_data
 
-        
     def _get_backend(self, backend_path):
         try:
             backend_module, backend_class = backend_path.rsplit('.', 1)
@@ -635,13 +648,12 @@ class EmailChangeForm(forms.Form):
         except (ImportError, AttributeError):
             return None
 
-    def _try_login_with_backend(self, backend, username, password):
-        try:
-            user = backend.get_user(User.objects.get(username=username).pk)
-            if user and user.check_password(password):
-                return user
-        except User.DoesNotExist:
+    def _try_login_with_backend(self, backend, target_user, password):
+        if target_user is None:
             return None
+        user = backend.get_user(target_user.pk)
+        if user and user.check_password(password):
+            return user
         return None
 
 # 활성화 메일 재전송 폼

--- a/site/judge/views/user.py
+++ b/site/judge/views/user.py
@@ -28,7 +28,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, FormView, ListView, TemplateView, View
 from reversion import revisions
 
-from judge.forms import CustomAuthenticationForm, DownloadDataForm, ProfileForm, newsletter_id, IdFindForm, CustomPasswordResetForm, EmailChangeForm, ResendActivationEmailForm
+from judge.forms import CustomAuthenticationForm, DownloadDataForm, ProfileForm, newsletter_id, IdFindForm, CustomPasswordResetForm, EmailChangeForm, ResendActivationEmailForm, get_email_domain_for_user
 from judge.models import Profile, Submission, ContestParticipation
 from judge.performance_points import get_pp_breakdown
 from judge.ratings import rating_class, rating_progress
@@ -705,28 +705,37 @@ class AdminOnlyMixin:
         return super().dispatch(request, *args, **kwargs)
 
 
+# 입력한 아이디(username)의 소속 학교에 맞는 이메일 도메인을 조회하는 용도.
+# 이메일 변경 화면에서 아이디 입력 시 표시 도메인을 실시간으로 갱신하기 위해 사용한다.
+# EmailChangeView와 동일하게 관리자만 호출 가능(비관리자가 API를 직접 두드려
+# 아이디→소속 학교를 알아내는 것을 막기 위함).
+def email_change_domain_lookup(request):
+    if not (
+        request.user.is_authenticated and
+        (request.user.is_staff or request.user.is_superuser)
+    ):
+        raise Http404
+    username = (request.GET.get('username') or '').strip()
+    target_user = User.objects.filter(username=username).first() if username else None
+    return JsonResponse({'domain': get_email_domain_for_user(target_user)})
+
+
 class EmailChangeView(AdminOnlyMixin, FormView):
     title = _('이메일 변경')
     form_class = EmailChangeForm
-    template_name = 'registration/email_change.html'  
+    template_name = 'registration/email_change.html'
     success_url = reverse_lazy('email_change_complete')
-    fixed_domain = '@jbnu.ac.kr'
-    
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['title'] = self.title
         return context
 
     def form_valid(self, form):
-        username = form.cleaned_data['username']
-        email_local = form.cleaned_data['email_local']
-        new_email = f"{email_local}{self.fixed_domain}"
-
-        try:
-            user = User.objects.get(username=username)
-        except User.DoesNotExist:
-            form.add_error('username', _('아이디 또는 비밀번호가 잘못되었습니다.'))
-            return self.form_invalid(form)
+        # user/email 모두 EmailChangeForm.clean()에서 이미 조회·계산됨
+        # (clean()을 통과했다는 것은 인증까지 성공했다는 뜻이므로 target_user는 항상 존재)
+        user = form.cleaned_data['target_user']
+        new_email = form.cleaned_data['email']
 
         # 이메일을 새로 설정하고 인증 전까지 비활성화
         user.email = new_email
@@ -742,7 +751,7 @@ class EmailChangeView(AdminOnlyMixin, FormView):
 
         return super().form_valid(form)
 
-# 이메일 변경 완료 클래스 (활성화가 되지 않은 계정)  
+# 이메일 변경 완료 클래스 (활성화가 되지 않은 계정)
 class EmailChangeCompleteView(AdminOnlyMixin, TemplateView):
     template_name = 'registration/email_change_complete.html'
     title = _('이메일 변경 완료')

--- a/site/templates/registration/email_change.html
+++ b/site/templates/registration/email_change.html
@@ -169,7 +169,7 @@
         <span class="email-input-wrapper{% if form.email_local.errors %}-error{% endif %}">
             {{ form.email_local }}
             {{ form.email_domain }}
-            <span class="email_domain">@jbnu.ac.kr</span>
+            <span class="email_domain" id="id_email_domain_display">{{ form.email_domain.value() or '@jbnu.ac.kr' }}</span>
         </span>
 
         {% if form.email_local.errors %}
@@ -179,4 +179,40 @@
         <button type="submit" class="button">{{ _('이메일 변경') }}</button>
     </form>
 </div>
+{% endblock %}
+
+{% block js_media %}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // 아이디(username)의 소속 학교에 따라 이메일 도메인(jbnu.ac.kr / g.jbedu.kr)을 자동으로 갱신한다.
+        var usernameField = document.querySelector('#id_username');
+        var domainDisplay = document.querySelector('#id_email_domain_display');
+        var domainField = document.querySelector('input[name=email_domain]');
+        var lookupUrl = '{{ url('email_change_domain_lookup') }}';
+
+        function updateDomain() {
+            var username = usernameField.value.trim();
+            if (!username) {
+                return;
+            }
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', lookupUrl + '?username=' + encodeURIComponent(username));
+            xhr.onload = function () {
+                if (xhr.status !== 200) {
+                    return;
+                }
+                try {
+                    var data = JSON.parse(xhr.responseText);
+                    domainDisplay.textContent = data.domain;
+                    domainField.value = data.domain;
+                } catch (e) {
+                    // 무시: 조회 실패 시 기존 표시값 유지
+                }
+            };
+            xhr.send();
+        }
+
+        usernameField.addEventListener('blur', updateDomain);
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
# 이메일 변경 시 사용자의 도메인을 DB에서 찾아 실시간 적용
- ### 전북대 학생 = jbnu.ac.kr, 외부 학생 = g.jbedu.kr

## 전북대 학생
<img width="613" height="515" alt="image" src="https://github.com/user-attachments/assets/99e29a3a-d4ae-4093-a3e1-5c89557c200d" />

## 외부 학생
<img width="573" height="475" alt="image" src="https://github.com/user-attachments/assets/42141ec0-c378-4284-baaa-533ede7d8c9e" />
