### PR TITLE
fix: 유저 랭킹에 동점 처리 없이 순차 번호 매기도록 변경

### DIFF
--- a/site/judge/views/user.py
+++ b/site/judge/views/user.py
@@ -2,7 +2,7 @@ import itertools
 import json
 import os
 from datetime import datetime
-from operator import attrgetter, itemgetter
+from operator import itemgetter
 
 from django.conf import settings
 from django.contrib.auth import logout as auth_logout
@@ -562,11 +562,8 @@ class UserList(QueryStringSortMixin, DiggPaginatorMixin, TitleMixin, ListView):
         context = super(UserList, self).get_context_data(**kwargs)
         context['title_info'] = self.title_info
         context['school'] = self.get_school()
-        context['users'] = ranker(
-            context['users'],
-            key=attrgetter('performance_points', 'problem_count'),
-            rank=self.paginate_by * (context['page_obj'].number - 1),
-        )
+        start = self.paginate_by * (context['page_obj'].number - 1)
+        context['users'] = enumerate(context['users'], start=start + 1)
         context['first_page_href'] = '.'
         context.update(self.get_sort_context())
         context.update(self.get_sort_paginate_context())


### PR DESCRIPTION
# 유저 탭의 번호 수정
- ### 유저 랭킹 목록의 번호를 동점자 공동 순위 방식에서 페이지 순서대로 매기는 단순 순차 번호(1, 2, 3, 4, 5…) 방식으로 변경했습니다.

## 수정 전
<img width="1310" height="860" alt="image" src="https://github.com/user-attachments/assets/f44f50ea-c3a7-45ba-b7f7-87b31d9124b6" />

## 수정 후
<img width="1316" height="856" alt="image" src="https://github.com/user-attachments/assets/c20a6d26-706e-4446-aa7a-3d74097954f1" />

### -> 기존에는 퍼포먼스 포인트(PP)와 해결한 문제 수가 같을 경우 동점 처리가 가능하게끔 ranker()함수로 처리되어있었고, 수정 후에는 그냥 순서대로 번호를 하나씩 붙여주는 파이썬 표준 함수인 enumerate() 함수로 ranker() 함수를 대체하였다.
