### PR TITLE
feat: 프로필 수정에서 학과 변경 기능 추가

### DIFF
--- a/site/judge/forms.py
+++ b/site/judge/forms.py
@@ -20,7 +20,7 @@ from django.utils.translation import gettext_lazy as _, ngettext_lazy
 from django_ace import AceWidget
 # from judge.models import Contest, Language, Organization, Problem, ProblemPointsVote, Profile, Submission, \
 #     WebAuthnCredential
-from judge.models import Contest, Language, Problem, ProblemPointsVote, Profile, Submission, \
+from judge.models import Contest, Department, Language, Problem, ProblemPointsVote, Profile, Submission, \
     WebAuthnCredential
 from judge.utils.subscription import newsletter_id
 from judge.widgets import HeavyPreviewPageDownWidget, Select2MultipleWidget, Select2Widget
@@ -63,13 +63,14 @@ class ProfileForm(ModelForm):
     class Meta:
         model = Profile
         # fields = ['about', 'organizations', 'timezone', 'language', 'ace_theme', 'user_script']
-        fields = ['about', 'timezone', 'language', 'ace_theme', 'site_theme', 'user_script']
+        fields = ['about', 'timezone', 'language', 'ace_theme', 'site_theme', 'user_script', 'department']
         widgets = {
             'user_script': AceWidget(theme='github'),
             'timezone': Select2Widget(attrs={'style': 'width:200px'}),
             'language': Select2Widget(attrs={'style': 'width:200px'}),
             'ace_theme': Select2Widget(attrs={'style': 'width:200px'}),
             'site_theme': Select2Widget(attrs={'style': 'width:200px'}),
+            'department': Select2Widget(attrs={'style': 'width:200px'}),
         }
 
         has_math_config = bool(settings.MATHOID_URL)
@@ -128,6 +129,20 @@ class ProfileForm(ModelForm):
         #     )
         # if not self.fields['organizations'].queryset:
         #     self.fields.pop('organizations')
+
+        # 전과/계열제 학부 선택 등으로 학과가 바뀐 사용자가 직접 수정할 수 있도록 함.
+        # 중/고등학생(비전북대 학교 소속)은 학과 개념이 없으므로 필드를 제거.
+        school = self.instance.school if self.instance and self.instance.pk else None
+        if school is not None and not school.is_jbnu:
+            self.fields.pop('department')
+        else:
+            self.fields['department'].queryset = Department.objects.exclude(name='중/고등학생').order_by('name')
+            self.fields['department'].required = True
+            # 모델 필드가 null 허용이라 위젯이 required=False로 생성되는데,
+            # Select2가 이를 보고 clear(x) 버튼을 붙이므로 위젯에도 반영해야 함.
+            self.fields['department'].widget.is_required = True
+            self.fields['department'].empty_label = None
+            self.fields['department'].label = _('학과')
 
 
 class DownloadDataForm(Form):

--- a/site/templates/user/edit-profile.html
+++ b/site/templates/user/edit-profile.html
@@ -396,6 +396,13 @@
                         <label class="inline-header grayed">사이트 테마</label>
                         <span class="fullwidth">{{ form.site_theme }}</span>
                     </div>
+                    {% if form.department %}
+                        <div class="pane-div" style="margin-bottom: 15px;">
+                            <label class="inline-header grayed">학과</label>
+                            <span class="fullwidth">{{ form.department }}</span>
+                            {{ form.department.errors }}
+                        </div>
+                    {% endif %}
                     <div class="pane-div">
                         <label class="inline-header grayed">비밀번호</label>
                         <a href="{{ url('password_change') }}" class="inline-header edit-pw" style="line-height: 1.8em;">비밀번호 변경</a>


### PR DESCRIPTION
## 배경

- 25학번부터 계열제 입학이 도입되어, 1학년 때 "계열제"로 가입한 학생이
  2학년 진입 시 학부(예: 컴퓨터인공지능학부)로 소속을 변경해야 하는 상황이 발생함
- 전과 등으로 학과가 바뀐 사용자도 현재는 관리자가 admin에서 직접 수정해주는
  방법밖에 없어, 사용자가 스스로 변경할 수 있도록 함

## 변경 사항

- `ProfileForm`에 `department` 필드 추가 (`site/judge/forms.py`)
  - 프로필 수정 페이지의 "개인정보 수정" 영역에 학과 드롭다운 노출
    (`site/templates/user/edit-profile.html`)
  - 비전북대 학교 소속(중/고등학생) 계정에는 필드가 렌더링되지 않음
  - 학과 선택지에서 '중/고등학생' 제외, 필수 선택으로 강제
  - 모델 필드가 null 허용이라 Select2에 clear(x) 버튼이 붙는 문제가 있어
    위젯에 `is_required`를 명시해 다른 드롭다운과 UI 통일
<img width="515" height="604" alt="image" src="https://github.com/user-attachments/assets/780665f2-f6fa-4a10-904d-06a718319cbf" />

## 검증

- 전북대 소속 계정: 드롭다운 표시, 계열제 → 컴퓨터인공지능학부 변경 및 DB 반영 확인
- 중학교 소속 계정: 드롭다운 미표시 확인
- '중/고등학생'으로 변경 시도 시 폼 검증에서 차단되는 것 확인
- 변경 이력은 기존 edit_profile 뷰의 django-reversion revision으로 기록됨

## 배포 시 필요한 작업

- 운영 DB의 학과 테이블에 **"계열제" 행 추가 필요** (관리자 페이지 > 학과)
   - 요청 내용: 관리자 페이지(admin) > 학과(Department)에서 이름이 계열제인 학과를 하나 추가해주세요. 코드 변경 없이 행 추가만 하면 됩니다.

이름은 정확히 계열제로 입력해주세요 (앞뒤 공백 없이).

- 코드 변경과 독립적인 데이터 작업이며, 행을 추가하는 즉시 회원가입 폼의
  학과 리스트에도 노출됨 (의도된 동작)
- 마이그레이션 필요 여부에 따라 마이그레이션 필요 