### PR TITLE
fix: 2026-1 security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ logs/
 dmojsite/
 test/
 tmp/
+ex_files/
 
 # Temporary and log files
 nohup.out

--- a/site/judge/middleware.py
+++ b/site/judge/middleware.py
@@ -254,14 +254,49 @@ class SimpleCSPMiddleware:
             settings,
             'CSP_HEADER_VALUE',
             "default-src 'self'; "
-            "script-src 'self' 'nonce-{nonce}' 'strict-dynamic' https: cdnjs.cloudflare.com ajax.googleapis.com; "
+            "base-uri 'self'; "
+            "script-src 'self' 'nonce-{nonce}' 'strict-dynamic' cdnjs.cloudflare.com ajax.googleapis.com "
+            "code.jquery.com cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline' cdnjs.cloudflare.com maxcdn.bootstrapcdn.com; "
             "font-src 'self' maxcdn.bootstrapcdn.com cdnjs.cloudflare.com; "
             "img-src 'self' data: www.gravatar.com gravatar.com; "
+            "connect-src 'self'; "
+            "form-action 'self'; "
             "frame-ancestors 'none'; "
+            "manifest-src 'self'; "
             "object-src 'none'; "
+            "require-trusted-types-for 'script'; "
+        )
+        self.feed_csp_value = getattr(
+            settings,
+            'CSP_FEED_HEADER_VALUE',
+            "default-src 'none'; "
+            "base-uri 'none'; "
+            "script-src 'none'; "
+            "style-src 'none'; "
+            "font-src 'none'; "
+            "img-src 'none'; "
+            "connect-src 'none'; "
+            "form-action 'none'; "
+            "frame-ancestors 'none'; "
+            "manifest-src 'none'; "
+            "object-src 'none'; "
+            "require-trusted-types-for 'script'; "
         )
         self.csp_report_only_value = getattr(settings, 'CSP_REPORT_ONLY_VALUE', '')
+        self.trusted_types_bootstrap = (
+            '<script nonce="{nonce}" data-trusted-types-bootstrap>'
+            '(function(){{'
+            'if(window.trustedTypes&&!window.trustedTypes.defaultPolicy){{'
+            'window.trustedTypes.createPolicy("default",{{'
+            'createHTML:function(value){{return value;}},'
+            'createScript:function(value){{return value;}},'
+            'createScriptURL:function(value){{return value;}}'
+            '}});'
+            '}}'
+            '}})();'
+            '</script>'
+        )
 
     def __call__(self, request):
         request.csp_nonce = secrets.token_urlsafe(16)
@@ -270,6 +305,9 @@ class SimpleCSPMiddleware:
             csp_value = self.csp_value.format(nonce=request.csp_nonce)
         else:
             csp_value = self.csp_value
+        content_type = response.get('Content-Type', '').lower()
+        if content_type.startswith(('application/atom+xml', 'application/rss+xml')):
+            csp_value = self.feed_csp_value
         response['Content-Security-Policy'] = csp_value
         if self.csp_report_only_value:
             if '{nonce}' in self.csp_report_only_value:
@@ -278,11 +316,21 @@ class SimpleCSPMiddleware:
                 csp_ro_value = self.csp_report_only_value
             response['Content-Security-Policy-Report-Only'] = csp_ro_value
         # Inject nonce into script tags (inline and external) for HTML responses.
-        content_type = response.get('Content-Type', '')
         if (not response.streaming and 'text/html' in content_type and hasattr(response, 'content')):
             try:
                 content = response.content
                 if isinstance(content, bytes):
+                    if b'data-trusted-types-bootstrap' not in content:
+                        bootstrap = self.trusted_types_bootstrap.format(nonce=request.csp_nonce).encode()
+                        html_pattern = re.compile(br'(<html\b[^>]*>)', re.IGNORECASE)
+                        content, count = html_pattern.subn(
+                            lambda match: match.group(1) + bootstrap, content, count=1,
+                        )
+                        if not count:
+                            head_pattern = re.compile(br'(<head\b[^>]*>)', re.IGNORECASE)
+                            content = head_pattern.sub(
+                                lambda match: match.group(1) + bootstrap, content, count=1,
+                            )
                     pattern = re.compile(br'<script(?![^>]*\bnonce=)([^>]*)>')
                     replacement = br'<script nonce="' + request.csp_nonce.encode() + br'"\1>'
                     new_content = pattern.sub(replacement, content)
@@ -291,6 +339,17 @@ class SimpleCSPMiddleware:
                         if response.has_header('Content-Length'):
                             response['Content-Length'] = str(len(response.content))
                 else:
+                    if 'data-trusted-types-bootstrap' not in content:
+                        bootstrap = self.trusted_types_bootstrap.format(nonce=request.csp_nonce)
+                        html_pattern = re.compile(r'(<html\b[^>]*>)', re.IGNORECASE)
+                        content, count = html_pattern.subn(
+                            lambda match: match.group(1) + bootstrap, content, count=1,
+                        )
+                        if not count:
+                            head_pattern = re.compile(r'(<head\b[^>]*>)', re.IGNORECASE)
+                            content = head_pattern.sub(
+                                lambda match: match.group(1) + bootstrap, content, count=1,
+                            )
                     pattern = re.compile(r'<script(?![^>]*\bnonce=)([^>]*)>')
                     replacement = r'<script nonce="' + request.csp_nonce + r'"\1>'
                     new_content = pattern.sub(replacement, content)

--- a/site/judge/views/error.py
+++ b/site/judge/views/error.py
@@ -110,7 +110,7 @@ def error404(request, exception=None):
 def error403(request, exception=None):
     return error(request, {
         'id': 'unauthorized_access',
-        'description': _('no permission for %s') % request.path,
+        'description': _('no permission for this request'),
         'code': 403,
     }, 403)
 
@@ -118,7 +118,7 @@ def error403(request, exception=None):
 def error500(request):
     return error(request, {
         'id': 'invalid_state',
-        'description': _('corrupt page %s') % request.path,
+        'description': _('an unexpected error occurred'),
         'traceback': traceback.format_exc(),
         'code': 500,
     }, 500)

--- a/site/resources/common.js
+++ b/site/resources/common.js
@@ -156,10 +156,15 @@ $(function () {
         $nav_list.removeClass('show-list');
     });
 
+    window.getDmojCsrfToken = function () {
+        var token = document.querySelector('meta[name="csrf-token"]');
+        return token ? token.getAttribute('content') : '';
+    };
+
     $.ajaxSetup({
         beforeSend: function (xhr, settings) {
             if (!(/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) && !this.crossDomain)
-                xhr.setRequestHeader('X-CSRFToken', $.cookie('csrftoken'));
+                xhr.setRequestHeader('X-CSRFToken', window.getDmojCsrfToken());
         }
     });
 });

--- a/site/resources/dmmd-preview.js
+++ b/site/resources/dmmd-preview.js
@@ -20,7 +20,7 @@ $(function () {
                 $preview.addClass('dmmd-preview-stale');
                 $.post(preview_url, {
                     content: text,
-                    csrfmiddlewaretoken: $.cookie('csrftoken')
+                    csrfmiddlewaretoken: window.getDmojCsrfToken()
                 }, function (result) {
                     $content.html(result);
                     $preview.addClass('dmmd-preview-has-content').removeClass('dmmd-preview-stale');

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -22,6 +22,7 @@
 <head>
     <title>{% block title %}{{ title }} - {{ SITE_LONG_NAME }}{% endblock %}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token }}">
     {% if misc_config.meta_keywords %}
         <meta name="keywords" content="{{ misc_config.meta_keywords }}">
     {% endif %}

--- a/site/templates/contest/contest-tabs.html
+++ b/site/templates/contest/contest-tabs.html
@@ -114,7 +114,7 @@
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-CSRFToken': getCookie('csrftoken') // CSRF 토큰 설정
+                'X-CSRFToken': window.getDmojCsrfToken()
             },
             body: JSON.stringify({ code: enteredCode })
         })
@@ -131,21 +131,6 @@
         });
     }
 
-    // CSRF 토큰 가져오기 함수
-    function getCookie(name) {
-        let cookieValue = null;
-        if (document.cookie && document.cookie !== '') {
-            const cookies = document.cookie.split(';');
-            for (let i = 0; i < cookies.length; i++) {
-                const cookie = cookies[i].trim();
-                if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                    break;
-                }
-            }
-        }
-        return cookieValue;
-    }
 </script>
 
 <style>

--- a/site/templates/contest/list.html
+++ b/site/templates/contest/list.html
@@ -479,7 +479,7 @@
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-CSRFToken': getCookie('csrftoken') // CSRF 토큰 설정
+                    'X-CSRFToken': window.getDmojCsrfToken()
                 },
                 body: JSON.stringify({ code: enteredCode })
             })
@@ -496,21 +496,6 @@
             });
         }
     
-        function getCookie(name) {
-            let cookieValue = null;
-            if (document.cookie && document.cookie !== '') {
-                const cookies = document.cookie.split(';');
-                for (let i = 0; i < cookies.length; i++) {
-                    const cookie = cookies[i].trim();
-                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                        break;
-                    }
-                }
-            }
-            return cookieValue;
-        }
-
         function applyFilter() {
             const selectedSubjects = [];
             document.querySelectorAll('input[name="subject_id"]:checked').forEach(function(checkbox) {

--- a/site/templates/organization/base.html
+++ b/site/templates/organization/base.html
@@ -3,6 +3,7 @@
 <head>
     <title>{% block title %}{{ title }} - {{ SITE_LONG_NAME }}{% endblock %}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token }}">
     {% if misc_config.meta_keywords %}
         <meta name="keywords" content="{{ misc_config.meta_keywords }}">
     {% endif %}

--- a/site/templates/problem/list.html
+++ b/site/templates/problem/list.html
@@ -459,21 +459,6 @@
                     
                 }
             
-                function getCookie(name) {
-                    let cookieValue = null;
-                    if (document.cookie && document.cookie !== '') {
-                        const cookies = document.cookie.split(';');
-                        for (let i = 0; i < cookies.length; i++) {
-                            const cookie = cookies[i].trim();
-                            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                                break;
-                            }
-                        }
-                    }
-                    return cookieValue;
-                }
-            
             });
         </script>
         <script>
@@ -519,7 +504,7 @@
                     prep_form();
                     ($('<form>').attr('action', window.location.pathname + '?' + $form.serialize())
                         .append($('<input>').attr('type', 'hidden').attr('name', 'csrfmiddlewaretoken')
-                            .attr('value', $.cookie('csrftoken')))
+                            .attr('value', window.getDmojCsrfToken()))
                         .attr('method', 'POST').appendTo($('body')).submit());
                 });
 

--- a/site/templates/ticket/list.html
+++ b/site/templates/ticket/list.html
@@ -233,7 +233,7 @@ table.table.striped tr:nth-child(odd) {
             $('input#open, input#own').click(function () {
                 ($('<form>').attr('action', window.location.pathname + '?' + $('form#filter-form').serialize())
                     .append($('<input>').attr('type', 'hidden').attr('name', 'csrfmiddlewaretoken')
-                        .attr('value', $.cookie('csrftoken')))
+                        .attr('value', window.getDmojCsrfToken()))
                     .attr('method', 'POST').appendTo($('body')).submit());
             });
 


### PR DESCRIPTION
## 취약점

  2026년 1학기 보안 점검 결과 다음 문제가 확인되었다.

  - Content-Security-Policy 필수 지시문 누락
  - Trusted Types 강제 설정 누락
  - RSS·Atom 응답에 불필요한 HTML용 CSP 적용
  - 403·500 오류 응답을 통한 요청 경로 노출
  - JavaScript의 CSRF 쿠키 직접 참조
  - 보안 보고서 파일의 Git 추적 가능성

  ## 위험성

  CSP 설정이 충분하지 않으면 외부 또는 인라인 리소스를 이용한 XSS 공
  격 위험이 증가한다. 오류 응답에 요청 경로가 포함되면 애플리케이션
  의 URL과 내부 구조 정보가 노출될 수 있다.

  CSRF 쿠키를 JavaScript에서 직접 읽는 방식은 HttpOnly 설정 적용을
  방해한다. XSS가 발생하면 CSRF 토큰이 탈취될 가능성이 있다.


  ## 원인

  기존 CSP에는 base-uri, connect-src, form-action, manifest-src,
  Trusted Types 관련 설정이 없었다. 일반 HTML과 RSS·Atom 응답에도 동
  일한 CSP가 적용되고 있었다.

  CSRF 토큰은 $.cookie() 또는 각 템플릿에 중복 구현된 getCookie()를
  이용해 쿠키에서 읽었다. 403·500 오류 메시지에는 request.path가 직
  접 포함돼 있었다.


  ## 처리방법

  CSP 필수 지시문과 require-trusted-types-for 'script'를 추가했다.
  RSS·Atom 응답에는 모든 리소스를 차단하는 별도 CSP를 적용하고, HTML
  응답의 스크립트에는 요청별 nonce를 부여했다.

  CSRF 토큰은 HTML 메타 태그로 전달하고 window.getDmojCsrfToken() 공
  통 함수로 읽도록 변경했다. 기존 쿠키 직접 참조와 중복 getCookie()
  함수는 제거했다.

  403·500 오류 메시지는 요청 경로가 포함되지 않는 일반 문구로 변경했
  다. 보안 보고서가 저장되는 ex_files/는 Git 제외 목록에 추가했다.

  단, HTML CSP의 style-src 'unsafe-inline'과 스크립트 호스트
  allowlist는 남아 있어 후속 개선이 필요하다. Trusted Types 기본 정
  책도 입력값을 그대로 반환하므로 실제 방어 효과를 높이기 위한 추가
  검토가 필요하다.


  ## 수정한 파일

  - site/judge/middleware.py

  CSP 필수 지시문과 Trusted Types 설정이 누락된 문제를 처리했다. CSP 지시문을 보강하고 RSS·Atom 전용 정책과 Trusted Types 기본 정책을 추가했다.

  - site/judge/views/error.py

  403·500 오류 메시지에 요청 경로가 포함되는 문제를 처리했다. 경로를 포함하지 않는 일반 오류 메시지로 변경했다.

  - site/resources/common.js

  JavaScript가 CSRF 쿠키를 직접 참조하는 문제를 처리했다. 메타 태그에서 토큰을 읽는 window.getDmojCsrfToken() 공통 함수를 추가했다.

  - site/resources/dmmd-preview.js

  Markdown 미리보기 요청이 CSRF 쿠키에 의존하는 문제를 처리했다. 공통 CSRF 토큰 함수를 사용하도록 변경했다.

  - site/templates/base.html

  JavaScript에 CSRF 토큰을 안전하게 전달할 수단이 없었다. <metaname="csrf-token"> 태그를 추가했다.

  - site/templates/organization/base.html

  조직 페이지에도 CSRF 토큰 전달 수단이 필요했다. 기본 템플릿과 동일한 CSRF 메타 태그를 추가했다.

  - site/templates/contest/contest-tabs.html

  대회 참가 코드 검증 요청이 쿠키에서 CSRF 토큰을 직접 읽고 있었다.
  공통 함수를 사용하도록 변경하고 중복 getCookie() 함수를 제거했다.

  - site/templates/contest/list.html

  대회 목록의 코드 검증 요청이 쿠키에 의존하고 있었다. 공통 CSRF 토큰 함수로 교체하고 중복 쿠키 함수를 제거했다.

  - site/templates/problem/list.html

  문제 필터 POST 요청이 CSRF 쿠키를 직접 읽고 있었다. 공통 함수를 사용하도록 변경하고 불필요한 getCookie() 함수를 제거했다.

  - site/templates/ticket/list.html

  티켓 필터 POST 요청이 CSRF 쿠키에 의존하고 있었다. 공통 CSRF 토큰 함수를 사용하도록 변경했다.

  - .gitignore

  보안 보고서 PDF를 ex_files/ 에 저장해놔서 이 디렉토리가 올라가는 것을 방지하기 위해 ex_files/ 디렉터리를 Git 제외 목록에 추가했다.


**[최종 결과]**
  - 상: 29/29 해결
  - 중: 11/59 해결, 48/59 미해결
  - 하: 47/51 해결, 4/51 미해결

ps. 중/하 더 해결하고 또 올리겠습니다...