### PR TITLE
fix: 관리자 페이지 학교 필터 스타일 개선

### DIFF
--- a/site/judge/admin/school.py
+++ b/site/judge/admin/school.py
@@ -1,7 +1,65 @@
 from django.contrib import admin
 from django import forms
+from django.contrib.admin.filters import FieldListFilter
 
 from judge.models import School
+
+
+class CombinedSchoolFilter(FieldListFilter):
+    title = ' '
+    template = 'admin/input_filter/input_filter_school.html'
+
+    def __init__(self, field, request, params, model, model_admin, field_path):
+        super().__init__(field, request, params, model, model_admin, field_path)
+        self.request = request
+        self.params = params
+
+        self.__school_type_lookups = tuple(School.SCHOOL_TYPES)
+        self.__school_type_handles = set(value for value, _ in self.__school_type_lookups)
+
+        self.__is_jbnu_lookups = (('1', '전북대'), ('0', '전북대 아님'))
+        self.__is_active_lookups = (('1', '활성'), ('0', '비활성'))
+        self.__boolean_handles = {'1', '0'}
+
+        self.filter_keys = ['school_type', 'is_jbnu', 'is_active']
+
+    @property
+    def school_type_lookups(self):
+        return self.__school_type_lookups
+
+    @property
+    def is_jbnu_lookups(self):
+        return self.__is_jbnu_lookups
+
+    @property
+    def is_active_lookups(self):
+        return self.__is_active_lookups
+
+    def expected_parameters(self):
+        return ['school_type', 'is_jbnu', 'is_active']
+
+    def choices(self, changelist):
+        yield {
+            'selected': False,
+            'query_string': changelist.get_query_string(remove=self.expected_parameters()),
+            'display': '초기화',
+        }
+
+    def queryset(self, request, queryset):
+        school_type = request.GET.get('school_type')
+        is_jbnu = request.GET.get('is_jbnu')
+        is_active = request.GET.get('is_active')
+
+        if school_type in self.__school_type_handles:
+            queryset = queryset.filter(school_type=school_type)
+
+        if is_jbnu in self.__boolean_handles:
+            queryset = queryset.filter(is_jbnu=(is_jbnu == '1'))
+
+        if is_active in self.__boolean_handles:
+            queryset = queryset.filter(is_active=(is_active == '1'))
+
+        return queryset
 
 
 class CustomActionForm(forms.Form):
@@ -15,7 +73,9 @@ class CustomActionForm(forms.Form):
 
 class SchoolAdmin(admin.ModelAdmin):
     list_display = ['name', 'short_name', 'school_type', 'is_jbnu', 'is_active']
-    list_filter = ['school_type', 'is_jbnu', 'is_active']
+    list_filter = (
+        ('id', CombinedSchoolFilter),
+    )
     search_fields = ['name', 'short_name']
     fields = ('name', 'short_name', 'school_type', 'is_jbnu', 'is_active')
     action_form = CustomActionForm

--- a/site/templates/admin/input_filter/input_filter_school.html
+++ b/site/templates/admin/input_filter/input_filter_school.html
@@ -1,0 +1,45 @@
+<head>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
+    crossorigin="anonymous"
+  >
+</head>
+<form method="get">
+  {% for key, value in request.GET.items %}
+    {% if key not in spec.filter_keys %}
+        <input type="hidden" name="{{ key }}" value="{{ value }}">
+    {% endif %}
+    {% endfor %}
+<label>
+  학교 구분
+  <select name="school_type">
+    <option value="">학교 구분</option>
+    {% for value, label in spec.school_type_lookups %}
+      <option value="{{ value }}" {% if request.GET.school_type == value %}selected{% endif %}>{{ label }}</option>
+    {% endfor %}
+  </select>
+</label>
+<label>
+  전북대 여부
+  <select name="is_jbnu">
+    <option value="">전북대 여부</option>
+    {% for value, label in spec.is_jbnu_lookups %}
+      <option value="{{ value }}" {% if request.GET.is_jbnu == value %}selected{% endif %}>{{ label }}</option>
+    {% endfor %}
+  </select>
+</label>
+<label>
+  활성화 상태
+  <select name="is_active">
+    <option value="">활성화 상태</option>
+    {% for value, label in spec.is_active_lookups %}
+      <option value="{{ value }}" {% if request.GET.is_active == value %}selected{% endif %}>{{ label }}</option>
+    {% endfor %}
+  </select>
+</label>
+  <button type="submit" style="font-size: 14px;">
+  <i class="fa-solid fa-filter"></i> 필터 적용
+</button>
+</form>


### PR DESCRIPTION
## 수정 이유 / 원인
<img width="941" height="217" alt="image" src="https://github.com/user-attachments/assets/8a1ea237-bf9f-4aed-91f3-4e67df4df045" />
관리자 페이지의 학교(judge/school) 목록 필터가 Django 기본 사이드바 필터(링크 나열 방식)로 되어 있어,
Submission 관리자 페이지의 통합 필터 UI(셀렉트박스 + 필터 적용 버튼)와 스타일이 일치하지 않았음.
관리자 페이지 전반의 필터 UI 일관성을 위해 학교 필터도 동일한 방식으로 변경 필요.

## 바꾼 방법

- `judge/admin/school.py`: Submission의 `CombinedSubmissionFilter`와 동일한 패턴으로
  `CombinedSchoolFilter(FieldListFilter)` 추가.
  - 학교 구분(`school_type`), 전북대 여부(`is_jbnu`), 활성화 상태(`is_active`)를
    GET 파라미터로 받아 하나의 필터에서 처리
  - 허용된 값만 필터링에 사용(잘못된 값은 무시), "초기화" 링크 제공
  - `list_filter`를 기존 3개 개별 필터에서 `(('id', CombinedSchoolFilter),)`로 교체
- `templates/admin/input_filter/input_filter_school.html` 신규 추가:
  기존 `input_filter_submission.html` 기반으로 셀렉트 3개(학교 구분/전북대 여부/활성화 상태) +
  "필터 적용" 버튼 구성. 필터 외 GET 파라미터(검색어 등)는 hidden input으로 유지.

## 확인 방법
<img width="1140" height="297" alt="image" src="https://github.com/user-attachments/assets/75dae8ec-416c-4a58-b41a-894e73774a1c" />

1. 관리자 페이지 → 학교(`/admin/judge/school/`) 접속
2. 필터 영역이 Submission과 동일한 셀렉트박스 + "필터 적용" 버튼 UI로 표시되는지 확인
3. 학교 구분 / 전북대 여부 / 활성화 상태를 각각 단독 적용 및 조합 적용 시 목록이 올바르게 필터링되는지 확인
4. "초기화" 클릭 시 필터가 해제되는지 확인
5. 이름/약칭 검색과 필터를 함께 사용할 때 검색어가 유지되는지 확인