### PR TITLE
feature: 문제 목록 기간별 CSV/엑셀 다운로드 기능 추가

### DIFF
--- a/site/dmoj/urls.py
+++ b/site/dmoj/urls.py
@@ -127,6 +127,7 @@ urlpatterns = [
     path('', include('social_django.urls')),
 
     path('problems/', problem.ProblemList.as_view(), name='problem_list'),
+    path('problems/export/', problem.ProblemExportView.as_view(), name='problem_export'),
     path('problems/random/', problem.RandomProblem.as_view(), name='problem_random'),
     path('path-to-your-view/', problem.GroupIdReceiverView.as_view(), name='group_id_receiver'),
     path('problem/<str:problem>', include([

--- a/site/judge/views/problem.py
+++ b/site/judge/views/problem.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import logging
 import os
@@ -5,7 +6,8 @@ import re
 import shutil
 import hashlib
 import base64
-from datetime import timedelta
+from datetime import datetime, timedelta
+from io import BytesIO
 from operator import itemgetter
 from random import randrange
 from statistics import mean, median
@@ -27,7 +29,8 @@ from django.utils.functional import cached_property
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _, gettext_lazy
-from django.views.generic import DetailView, ListView, View
+from django.views.generic import DetailView, ListView, TemplateView, View
+from openpyxl import Workbook
 from django.views.generic.detail import SingleObjectMixin
 from django.views.decorators.http import require_POST
 from reversion import revisions
@@ -847,6 +850,116 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
                     current[part] = {}
                 current = current[part]
         return data
+
+
+class ProblemExportView(LoginRequiredMixin, TitleMixin, TemplateView):
+    template_name = 'problem/export.html'
+    title = gettext_lazy('문제 목록 다운로드')
+
+    def has_export_permission(self):
+        required_perms = ('judge.view_all_problem', 'judge.edit_all_problem',
+                          'judge.edit_public_problem', 'judge.edit_own_problem')
+        return any(self.request.user.has_perm(perm) for perm in required_perms)
+
+    def get(self, request, *args, **kwargs):
+        if not self.has_export_permission():
+            raise PermissionDenied()
+
+        start = request.GET.get('start')
+        end = request.GET.get('end')
+        if not start or not end:
+            return self.render_to_response(self.get_context_data())
+
+        try:
+            start_date = datetime.strptime(start, '%Y-%m-%d').date()
+            end_date = datetime.strptime(end, '%Y-%m-%d').date()
+        except ValueError:
+            return self.render_to_response(self.get_context_data(
+                start=start, end=end, error=_('날짜 형식이 올바르지 않습니다.'),
+            ))
+
+        if start_date > end_date:
+            return self.render_to_response(self.get_context_data(
+                start=start, end=end, error=_('시작일이 종료일보다 늦을 수 없습니다.'),
+            ))
+
+        problems = (
+            Problem.objects.filter(date__date__range=(start_date, end_date))
+            .select_related('group')
+            .prefetch_related('authors__user', 'allowed_languages')
+            .annotate(
+                total_submission_count=Count('submission', distinct=True),
+                ac_submission_count=Count(
+                    'submission',
+                    filter=Q(submission__result='AC', submission__case_points__gte=F('submission__case_total')),
+                    distinct=True,
+                ),
+            )
+            .order_by('date')
+        )
+
+        headers = [
+            _('문제 코드'), _('문제명'), _('출제자'), _('등록일'), _('배점'),
+            _('카테고리'), _('공개 여부'), _('대회 전용 여부'), _('푼 유저 수'), _('정답률(%)'),
+            _('부분점수 허용'), _('허용 언어'), _('제출 소스 공개 범위'), _('총 제출 수'), _('정답 제출 수'),
+        ]
+        rows = []
+        for problem in problems:
+            authors = ', '.join(author.username for author in problem.authors.all())
+            languages = ', '.join(sorted(set(lang.common_name for lang in problem.allowed_languages.all())))
+            problem_date = problem.date
+            if timezone.is_naive(problem_date):
+                problem_date = timezone.make_aware(problem_date, timezone.get_default_timezone())
+            rows.append([
+                problem.code,
+                problem.name,
+                authors,
+                timezone.localtime(problem_date).strftime('%Y-%m-%d %H:%M'),
+                problem.points,
+                problem.group.full_name if problem.group_id else '',
+                _('공개') if problem.is_public else _('비공개'),
+                _('대회 전용') if problem.is_contest_problem else _('일반'),
+                problem.user_count,
+                round(problem.ac_rate, 1),
+                _('허용') if problem.partial else _('비허용'),
+                languages,
+                problem.get_submission_source_visibility_mode_display(),
+                problem.total_submission_count,
+                problem.ac_submission_count,
+            ])
+
+        file_format = request.GET.get('format', 'xlsx')
+        if file_format == 'csv':
+            return self.build_csv_response(headers, rows, start, end)
+        return self.build_xlsx_response(headers, rows, start, end)
+
+    def build_csv_response(self, headers, rows, start, end):
+        response = HttpResponse(content_type='text/csv; charset=utf-8')
+        response['Content-Disposition'] = 'attachment; filename="problems_%s_%s.csv"' % (start, end)
+        response.write('﻿')
+        writer = csv.writer(response)
+        writer.writerow(headers)
+        writer.writerows(rows)
+        return response
+
+    def build_xlsx_response(self, headers, rows, start, end):
+        wb = Workbook()
+        ws = wb.active
+        ws.title = '문제 목록'
+        ws.append(headers)
+        for row in rows:
+            ws.append(row)
+
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+
+        response = HttpResponse(
+            output,
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+        response['Content-Disposition'] = 'attachment; filename="problems_%s_%s.xlsx"' % (start, end)
+        return response
 
 
 class LanguageTemplateAjax(View):

--- a/site/templates/contest/contest-list-tabs.html
+++ b/site/templates/contest/contest-list-tabs.html
@@ -19,11 +19,16 @@
 {% endblock %}
 
 {% block admin_tab %}
-{% if perms.judge.edit_all_contest or perms.judge.edit_own_contest %}
+{% if perms.judge.edit_all_contest or perms.judge.edit_own_contest or perms.judge.view_all_problem or perms.judge.edit_all_problem or perms.judge.edit_public_problem or perms.judge.edit_own_problem %}
     <div class="admin-tab">
-        {{ make_tab('admin', 'fa-edit', url('admin:judge_contest_changelist'), _('Admin')) }}
+        {% if perms.judge.edit_all_contest or perms.judge.edit_own_contest %}
+            {{ make_tab('admin', 'fa-edit', url('admin:judge_contest_changelist'), _('Admin')) }}
+        {% endif %}
+        {% if perms.judge.view_all_problem or perms.judge.edit_all_problem or perms.judge.edit_public_problem or perms.judge.edit_own_problem %}
+            {{ make_tab('problem_export', 'fa-download', url('problem_export'), _('문제 다운로드')) }}
+        {% endif %}
     </div>
-{% endif %}  
+{% endif %}
 {% endblock %}
 
 {% block tabs %}

--- a/site/templates/contest/contest-tabs.html
+++ b/site/templates/contest/contest-tabs.html
@@ -5,12 +5,17 @@
 {% endblock %}
 
 {% block admin_tab %}
-    {% if can_edit %}
+    {% if can_edit or perms.judge.view_all_problem or perms.judge.edit_all_problem or perms.judge.edit_public_problem or perms.judge.edit_own_problem %}
     <div class="admin-tab">
-        {{ make_tab('edit', 'fa-edit', url('admin:judge_contest_change', contest.id), _('Edit')) }}
-        {{ make_tab('clone', 'fa-copy', url('contest_clone', contest.key), '복사') }}
-        {{ make_tab('download', 'fa-download', url('contest_detail_excel_download', contest.key), '결과 다운로드') }}
-        {{ make_tab('code_download', 'fa-code', url('contest_detail_code_download', contest.key), '코드 다운로드') }}
+        {% if can_edit %}
+            {{ make_tab('edit', 'fa-edit', url('admin:judge_contest_change', contest.id), _('Edit')) }}
+            {{ make_tab('clone', 'fa-copy', url('contest_clone', contest.key), '복사') }}
+            {{ make_tab('download', 'fa-download', url('contest_detail_excel_download', contest.key), '결과 다운로드') }}
+            {{ make_tab('code_download', 'fa-code', url('contest_detail_code_download', contest.key), '코드 다운로드') }}
+        {% endif %}
+        {% if perms.judge.view_all_problem or perms.judge.edit_all_problem or perms.judge.edit_public_problem or perms.judge.edit_own_problem %}
+            {{ make_tab('problem_export', 'fa-download', url('problem_export'), _('문제 다운로드')) }}
+        {% endif %}
     </div>
     {% endif %}
 {% endblock %}

--- a/site/templates/problem/export.html
+++ b/site/templates/problem/export.html
@@ -1,0 +1,178 @@
+{% extends "common-content.html" %}
+
+{% block title_ruler %}{% endblock %}
+
+{% block title_row %}
+    {% set tab = 'problem_export' %}
+    {% include "problem/problem-list-tabs.html" %}
+{% endblock %}
+
+{% block content_media %}
+<style>
+    .export-form {
+        max-width: 480px;
+        margin: 40px auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+    .export-form h3 {
+        margin: 0;
+    }
+    .export-form p {
+        margin: 0;
+        color: var(--font-grey);
+    }
+    .export-form .field-row {
+        display: flex;
+        gap: 12px;
+    }
+    .export-form .field {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+    .export-form label {
+        font-weight: 500;
+    }
+    .export-form input[type="date"] {
+        height: 38px;
+        border-radius: 8px;
+        border: 1px solid var(--input-border);
+        padding: 0 10px;
+        cursor: pointer;
+    }
+    .export-form input[type="date"]::-webkit-calendar-picker-indicator {
+        cursor: pointer;
+    }
+    .export-form .format-options {
+        display: flex;
+        gap: 20px;
+    }
+    .export-form .format-options label {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-weight: normal;
+    }
+    .export-form button {
+        height: 40px;
+        border-radius: 10px;
+        background: var(--LITMUS-Primary, #5C95D9);
+        color: white;
+        border: none;
+        cursor: pointer;
+        font-weight: 500;
+        font-size: 14px;
+    }
+    .export-error {
+        color: red;
+    }
+    .export-form button:disabled {
+        opacity: 0.6;
+        cursor: default;
+    }
+</style>
+{% endblock %}
+
+{% block body %}
+<form id="export-form" class="export-form" method="get" action="{{ url('problem_export') }}">
+    <h3>{{ _('문제 목록 다운로드') }}</h3>
+    <p>{{ _('설정한 기간 동안 새로 등록된 문제 목록을 CSV 또는 엑셀 파일로 다운로드합니다.') }}</p>
+
+    <div id="export-error" class="export-error" {% if not error %}style="display: none;"{% endif %}>{{ error or '' }}</div>
+
+    <div class="field-row">
+        <div class="field">
+            <label for="export-start">{{ _('시작일') }}</label>
+            <input type="date" id="export-start" name="start" value="{{ start or '' }}" required>
+        </div>
+        <div class="field">
+            <label for="export-end">{{ _('종료일') }}</label>
+            <input type="date" id="export-end" name="end" value="{{ end or '' }}" required>
+        </div>
+    </div>
+
+    <div class="field">
+        <label>{{ _('파일 형식') }}</label>
+        <div class="format-options">
+            <label><input type="radio" name="format" value="xlsx" checked> xlsx</label>
+            <label><input type="radio" name="format" value="csv"> csv</label>
+        </div>
+    </div>
+
+    <button id="export-submit" type="submit">{{ _('다운로드') }}</button>
+</form>
+{% endblock %}
+
+{% block content_js_media %}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var form = document.getElementById('export-form');
+        var button = document.getElementById('export-submit');
+        var errorBox = document.getElementById('export-error');
+
+        ['export-start', 'export-end'].forEach(function (id) {
+            var input = document.getElementById(id);
+            input.addEventListener('click', function () {
+                if (typeof input.showPicker === 'function') {
+                    input.showPicker();
+                }
+            });
+        });
+
+        function showError(message) {
+            errorBox.textContent = message;
+            errorBox.style.display = message ? 'block' : 'none';
+        }
+
+        function parseFilename(disposition) {
+            if (!disposition) return 'download';
+            var utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/);
+            if (utf8Match) return decodeURIComponent(utf8Match[1]);
+            var plainMatch = disposition.match(/filename="?([^";]+)"?/);
+            return plainMatch ? plainMatch[1] : 'download';
+        }
+
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            showError('');
+            button.disabled = true;
+
+            var params = new URLSearchParams(new FormData(form));
+            var url = form.action + '?' + params.toString();
+
+            fetch(url, { credentials: 'same-origin' })
+                .then(function (response) {
+                    var contentType = response.headers.get('Content-Type') || '';
+                    if (contentType.indexOf('text/html') !== -1) {
+                        return response.text().then(function (html) {
+                            var doc = new DOMParser().parseFromString(html, 'text/html');
+                            var errorEl = doc.querySelector('#export-error');
+                            showError(errorEl && errorEl.textContent.trim() ? errorEl.textContent.trim() : '{{ _("다운로드에 실패했습니다.") }}');
+                        });
+                    }
+
+                    var filename = parseFilename(response.headers.get('Content-Disposition'));
+                    return response.blob().then(function (blob) {
+                        var blobUrl = window.URL.createObjectURL(blob);
+                        var a = document.createElement('a');
+                        a.href = blobUrl;
+                        a.download = filename;
+                        document.body.appendChild(a);
+                        a.click();
+                        a.remove();
+                        window.URL.revokeObjectURL(blobUrl);
+                    });
+                })
+                .catch(function () {
+                    showError('{{ _("다운로드에 실패했습니다.") }}');
+                })
+                .finally(function () {
+                    button.disabled = false;
+                });
+        });
+    });
+</script>
+{% endblock %}

--- a/site/templates/problem/problem-list-tabs.html
+++ b/site/templates/problem/problem-list-tabs.html
@@ -4,13 +4,14 @@
 {% if perms.judge.view_all_problem or perms.judge.edit_all_problem or perms.judge.edit_public_problem or perms.judge.edit_own_problem %}
     <div class="admin-tab">
         {{ make_tab('admin', 'fa-edit', url('admin:judge_problem_changelist'), _('Admin')) }}
+        {{ make_tab('problem_export', 'fa-download', url('problem_export'), _('문제 다운로드')) }}
     </div>
-{% endif %}  
+{% endif %}
 {% endblock %}
 
 {% block tabs %}
     {% if perms.judge.view_all_problem or perms.judge.edit_all_problem or perms.judge.edit_public_problem or perms.judge.edit_own_problem %}
         {{ make_tab('list', 'fa-list', url('problem_list'), _('List')) }}
     {% endif %}
-    
+
 {% endblock %}


### PR DESCRIPTION
# 문제 목록 기간별 CSV/엑셀 다운로드 기능 추가

<img width="1918" height="910" alt="image" src="https://github.com/user-attachments/assets/d7efb1be-c166-4250-a325-c4cb07a41dd3" />
<img width="1918" height="911" alt="image" src="https://github.com/user-attachments/assets/0e9f3507-3f0f-448e-9714-ac9df4d674a6" />
<img width="1918" height="910" alt="image" src="https://github.com/user-attachments/assets/ee2d8924-472a-4de4-a0bd-85525060a6db" />

## xlsx 파일 다운로드
<img width="1918" height="1021" alt="image" src="https://github.com/user-attachments/assets/12c01019-67e9-44b9-98c6-084c654923c7" />

## csv 파일 다운로드
<img width="1918" height="981" alt="image" src="https://github.com/user-attachments/assets/14ad546b-a136-46a9-89b2-005b1c0aae60" />

## 파일 구조 설명
### 1. site/dmoj/urls.py
- problems/export/ url 주소 추가

### 2. site/judge/views/problem.py(백)
- 일반 회원이 가지지 못하는 4가지 권한을 체크(유저가 문제 전체 열람 권한, 전체 편집 권한, 공개 문제 편집 권한, 본인 문제 편집 권한 중 하나라도 가지면 True) -> 날짜 파라미터(start/end)가 없으면 그냥 빈 폼 보여주고,
날짜 형식이 이상하거나 시작일 > 종료일이면 에러 메시지를 띄움 -> DB에서 입력한 기간 안에 있는 문제만 골라내서 내용들 미리 가져옴 -> 문제 코드, 문제명 등 원하는 카테고리에 해당하는 내용들을 한줄로 만들어서 출력

### 3. site/templates/contest/contest-list-tabs.html(프론트)
- 대회 목록 페이지에서 일반 회원이 가지지 못하는 4가지 권한을 체크하고, 권한이 하나도 없을 경우 다운로드 버튼 숨김

### 4. site/templates/contest/contest-tabs.html(프론트)
- 개별 대회 상세 페이지에서 일반 회원이 가지지 못하는 4가지 권한을 체크하고, 권한이 하나도 없을 경우 다운로드 버튼 숨김

### 5. site/templates/problem/export.html(프론트)
- "문제 다운로드" 버튼 클릭시 나오는 UI

### 6. site/templates/problem/problem-list-tabs.html(프론트)
- 문제 관련 권한(4가지 중 하나라도) 있는 유저에게만 admin-tab 영역을 보여줌