### PR TITLE
fix: 대회 결과 JSON API 인증 우회 차단

### DIFF
--- a/site/judge/views/contests.py
+++ b/site/judge/views/contests.py
@@ -151,9 +151,14 @@ def verify_contest_code(request, contest_key):
 class ContestDetailJSON(View):
     def get(self, request, *args, **kwargs):
         contest_key = kwargs.get('contest')
-        contest, exists = _find_contest(request, contest_key, private_check=False)
+        contest, exists = _find_contest(request, contest_key)
         if not exists:
             return JsonResponse({'error': 'Contest not found'}, status=404)
+
+        # 권한 검증 로직 추가
+        if not (request.user.is_staff or contest.is_editable_by(request.user) or
+                request.user.has_perm('judge.see_private_contest')):
+            raise PermissionDenied("You don't have permission to view contest results.")
 
         contest_data = {
             'name': contest.name,


### PR DESCRIPTION
## 개요

`/contest/<key>/result` 엔드포인트에서 인증·권한 검사 없이 대회 정보가 노출되는 문제를 수정합니다.

## 문제 상황

`ContestDetailJSON` 뷰에 접근 제어가 전혀 없었습니다.

1. **`private_check=False`** — `_find_contest()`의 기본 접근 검사(`is_accessible_by()`)를 명시적으로 비활성화한 상태였습니다. `is_visible=False`(미공개) 또는 `is_private=True`(비공개) 대회도 키만 알면 조회 가능했습니다.
2. **뷰 내부 권한 검사 없음** — `ContestMixin`을 상속하지 않는 순수 `View`라 `access_check()`가 실행되지 않고, `get()` 안에도 검사 코드가 없었습니다.

그 결과 **비로그인 상태**에서 다음 정보가 노출되었습니다.
<img width="1919" height="964" alt="image" src="https://github.com/user-attachments/assets/4a97f97f-6a07-43cc-b4d5-59ba7fe976ad" />

- 대회 이름, 설명, 시작/종료 시각
- 작성자(authors) / 큐레이터(curators) / 테스터(testers) 계정명
- 문제 목록 (이름, 순서, 배점)
- 참가자 랭킹 (username, 점수, 문제별 결과)

랭킹은 `can_see_full_scoreboard()`가 `false`일 때 `???`로 마스킹되지만, 이 메서드는 `show_scoreboard`가 `true`면 로그인 여부를 확인하기 전에 `true`를 반환합니다. 즉 **시작된 대회이고 스코어보드가 HIDDEN이 아니면 익명 사용자에게 실명 랭킹이 그대로 노출**되었습니다.

## 변경 사항

`site/judge/views/contests.py` — `ContestDetailJSON.get()`

- `private_check=False` 인자를 제거해 `_find_contest()`의 기본 접근 검사를 복구했습니다. 접근 권한이 없는 대회는 404를 반환합니다.
- 동일 계열 엔드포인트인 `/codedownload`, `/resultdownload`와 같은 기준의 권한 검사를 추가했습니다. staff, 대회 편집 권한자, `judge.see_private_contest` 보유자만 접근할 수 있습니다.
<img width="1468" height="856" alt="image" src="https://github.com/user-attachments/assets/ffc87f00-19fc-4892-8b48-7b9c8bcc93d4" />

## 영향 범위

- 코드베이스 내에서 `contest_detail_json`을 참조하는 곳은 URL 정의 한 줄뿐입니다. 템플릿·JS에서 호출하지 않으므로 화면 동작에 영향이 없습니다.
- 기존에 이 엔드포인트를 외부 스크립트에서 사용 중이었다면 403이 반환됩니다.