### PR TITLE
fix: 유저 생성 시 Profile 중복 생성 오류 수정

### DIFF
--- a/site/judge/admin/users.py
+++ b/site/judge/admin/users.py
@@ -4,7 +4,6 @@ from django.contrib.auth.admin import UserAdmin as OldUserAdmin
 from django.contrib.admin.filters import FieldListFilter
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
-from judge.models import Profile
 
 class Users(AbstractUser):
     
@@ -121,8 +120,3 @@ class UserAdmin(OldUserAdmin):
     
     date_joined_display.admin_order_field = 'date_joined'
     date_joined_display.short_description = _('가입 시간')
-    
-    def save_model(self, request, obj, form, change):
-        super().save_model(request, obj, form, change)
-        if not change:
-            Profile.objects.create(user=obj)

--- a/site/judge/management/commands/adduser.py
+++ b/site/judge/management/commands/adduser.py
@@ -27,6 +27,6 @@ class Command(BaseCommand):
         usr.is_staff = options['staff']
         usr.save()
 
-        profile = Profile(user=usr)
+        profile, _ = Profile.objects.get_or_create(user=usr)
         profile.language = Language.objects.get(key=options['language'])
         profile.save()


### PR DESCRIPTION
fix: 유저 생성 시 Profile 중복 생성 오류 수정

[증상]
관리자 페이지(/admin/auth/user/add/)에서 유저를 추가하면
IntegrityError (1062, "Duplicate entry for key 'user_id'")가 발생해
유저 추가가 불가능했다. manage.py adduser 명령도 같은 이유로 실패한다.

[원인]
judge/signals.py의 ensure_user_profile 시그널이 User 저장 시 Profile을
자동 생성한다. 이 시그널은 로그인 실패 잠금 기능(#72)이 잠금 상태를
Profile 필드에 저장하기 위해 추가된 것으로, 모든 User 생성 경로에
적용된다.

그런데 admin의 save_model과 adduser 명령이 같은 유저에 대해 Profile을
한 번 더 생성하면서 OneToOneField의 UNIQUE 제약을 위반했다.
회원가입 경로는 get_or_create를 사용하므로 영향이 없다.

[변경]
- admin: save_model 오버라이드와 미사용 Profile import를 제거해
  Profile 생성을 시그널에 일임한다.
- adduser: 언어 지정이 필요하므로 시그널이 만든 Profile을
  get_or_create로 가져와 재사용한다.

[결과]
관리자 페이지의 유저 추가와 adduser 명령이 정상 동작하고, 생성 경로와
무관하게 Profile이 정확히 한 개만 만들어진다. 실패한 저장은 트랜잭션
단위로 롤백돼 왔으므로 기존 데이터의 정합성 문제는 없다.