### PR TITLE
fix: 같은 학교 내 학번 중복 등록 방지

### DIFF
--- a/site/judge/forms.py
+++ b/site/judge/forms.py
@@ -679,6 +679,19 @@ class StudentNumberRegisterForm(forms.Form):
         label=_('학번'),
     )
 
+    def __init__(self, *args, profile=None, **kwargs):
+        self.profile = profile
+        super().__init__(*args, **kwargs)
+
+    def clean_student_number(self):
+        student_number = self.cleaned_data['student_number']
+        if self.profile and self.profile.school:
+            exists = Profile.objects.filter(school=self.profile.school, student_number=student_number) \
+                                    .exclude(pk=self.profile.pk).exists()
+            if exists:
+                raise forms.ValidationError(_('같은 학교에 동일한 학번이 이미 등록되어 있습니다.'), code='duplicate_student_number')
+        return student_number
+
 
 # 활성화 메일 재전송 폼
 class ResendActivationEmailForm(forms.Form):

--- a/site/judge/migrations/0034_profile_unique_school_student_number.py
+++ b/site/judge/migrations/0034_profile_unique_school_student_number.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('judge', '0033_profile_student_number'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='profile',
+            constraint=models.UniqueConstraint(
+                fields=('school', 'student_number'),
+                name='unique_school_student_number',
+            ),
+        ),
+    ]

--- a/site/judge/models/profile.py
+++ b/site/judge/models/profile.py
@@ -428,6 +428,9 @@ class Profile(models.Model):
             ('test_site', _('Shows in-progress development stuff')),
             ('totp', _('Edit TOTP settings')),
         )
+        constraints = [
+            UniqueConstraint(fields=['school', 'student_number'], name='unique_school_student_number'),
+        ]
         verbose_name = _('user profile')
         verbose_name_plural = _('user profiles')
 

--- a/site/judge/views/user.py
+++ b/site/judge/views/user.py
@@ -774,6 +774,11 @@ class StudentNumberRegisterView(LoginRequiredMixin, FormView):
             raise Http404()
         return super().dispatch(request, *args, **kwargs)
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['profile'] = self.request.profile
+        return kwargs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['title'] = self.title

--- a/site/templates/registration/student_number_register.html
+++ b/site/templates/registration/student_number_register.html
@@ -53,7 +53,7 @@
         flex-direction: column;
         align-items: center;
         gap: 6px;
-        margin: 0 0 24px;
+        margin: 0 0 12px;
         padding: 14px 16px;
         border-radius: 10px;
         background-color: rgba(230, 69, 69, 0.08);
@@ -63,10 +63,6 @@
         line-height: 1.5;
         text-align: center;
     }
-    .required-notice .material-symbols-outlined {
-        flex: 0 0 auto;
-        font-size: 22px;
-    }
 
     .form-area {
         display: flex;
@@ -74,11 +70,18 @@
         gap: 12px;
     }
 
-    #form-errors .error {
-        margin: 0 0 4px;
-        font-size: 13px;
-        color: #e64545;
+    .student-number-card #form-errors {
+        margin: 8px 0 0;
+        padding: 0;
+        background: none;
+        border: none;
         text-align: center;
+    }
+    #form-errors .error {
+        margin: 0;
+        font-size: 13px;
+        font-weight: 700;
+        color: #e64545;
     }
 
     .form-area input[type="text"] {
@@ -132,7 +135,6 @@
     <div class="student-number-icon material-symbols-outlined">school</div>
     <h2>학번 등록</h2>
     <div class="required-notice">
-        <span class="material-symbols-outlined">error</span>
         <span>학번이 등록되어 있지 않아 서비스를 이용하실 수 없습니다.<br>학번 등록은 필수입니다.</span>
     </div>
     <form action="" method="post" class="form-area">


### PR DESCRIPTION
# 같은 학교 + 같은 학번일 경우 학번 등록 안되게 막음
<img width="506" height="520" alt="image" src="https://github.com/user-attachments/assets/09b5d353-0e8b-4321-b3dd-6e3633039a0d" />

## 배경

중/고등학생 학번 등록 시 같은 학교 내에서 학번이 중복 등록될 수 있었음. 다른 학교의 동일 학번은 계속 허용하되, **같은 학교 + 같은 학번** 조합만 막도록 수정.

## 변경 사항

- `judge/models/profile.py`: `Profile.Meta.constraints`에 `(school, student_number)` 복합 UNIQUE 제약(`unique_school_student_number`) 추가. `school`이나 `student_number`가 비어있는(NULL) 프로필끼리는 서로 충돌하지 않음(MySQL 유니크 인덱스는 NULL을 서로 다른 값으로 취급).
- `judge/migrations/0034_profile_unique_school_student_number.py`: 위 제약을 실제 DB에 반영하는 마이그레이션 **(신규 파일)**.
- `judge/forms.py`: `StudentNumberRegisterForm`에 `clean_student_number` 추가. 저장 전에 미리 중복 여부를 조회해서, DB 에러 대신 "같은 학교에 동일한 학번이 이미 등록되어 있습니다." 안내 메시지를 보여줌.
- `judge/views/user.py`: `StudentNumberRegisterView.get_form_kwargs`에서 폼에 `profile`을 넘기도록 수정 (위 중복 검증에 필요).
- `templates/registration/student_number_register.html`: 에러 메시지 스타일 정리.

## 마이그레이션 필요 여부

**필요함.** 이 PR엔 새 마이그레이션(`0034_profile_unique_school_student_number`)이 포함되어 있어서, 배포 시 반드시 아래 명령을 실행해야 함.

​```bash
python manage.py migrate judge
​```

### 배포 전 확인할 것

- **이미 같은 학교 + 같은 학번으로 중복 등록된 데이터가 있으면 마이그레이션이 실패함**(UNIQUE 제약 생성 시 기존 중복을 걸러내지 못하고 에러 발생). 운영 DB에 아래 쿼리로 미리 확인 권장:
  ​```sql
  SELECT school_id, student_number, COUNT(*)
  FROM judge_profile
  WHERE school_id IS NOT NULL AND student_number IS NOT NULL
  GROUP BY school_id, student_number
  HAVING COUNT(*) > 1;
  ​```
  결과가 있으면 마이그레이션 전에 데이터 정리(중복 재등록 처리 등)가 먼저 필요함.
- 제약에 `condition`은 넣지 않음 — MySQL/MariaDB는 조건부(partial) 유니크 인덱스를 지원하지 않아, `condition`을 넣으면 Django가 경고만 띄우고 **제약 생성을 조용히 건너뜀**(개발 DB에서 실제로 이 문제로 헤맨 뒤 수정 확인함).

## 테스트

- 개발 서버에서 동일 학교 + 동일 학번으로 재등록 시도 → 정상 차단 및 안내 메시지 노출 확인 (스크린샷 첨부).
- 다른 학교 + 동일 학번은 정상 등록되는 것 확인.
