### PR TITLE
fix: site 테마와 editor 테마가 독립적이어서 맞지 않던 문제 해결

### DIFF
--- a/site/django_ace/static/django_ace/widget.js
+++ b/site/django_ace/static/django_ace/widget.js
@@ -1,4 +1,42 @@
 (function () {
+    // 사이트 테마(<html data-theme="dark">)에 맞춰 에디터 테마를 고른다.
+    // 서버에서 고르지 않는 이유: 프로필의 '시스템 기본값(auto)' 은 브라우저의
+    // prefers-color-scheme 으로만 판정되므로 서버가 알 수 없다. 여기서 판정하면
+    // light / dark / auto 세 경우가 모두 자동으로 맞는다.
+    var editors = [];
+
+    function siteIsDark() {
+        return document.documentElement.getAttribute('data-theme') === 'dark';
+    }
+
+    function resolveTheme(widget) {
+        var dark = widget.getAttribute('data-theme-dark');
+        if (dark && siteIsDark()) {
+            return dark;
+        }
+        return widget.getAttribute('data-theme');
+    }
+
+    function applyTheme(entry) {
+        var theme = resolveTheme(entry.widget);
+        if (theme) {
+            entry.editor.setTheme('ace/theme/' + theme);
+        }
+    }
+
+    // '시스템 기본값' 사용자가 OS 테마를 바꾸면 base.html 이 새로고침 없이
+    // <html data-theme> 만 토글한다. 그때 에디터도 같이 따라가도록 감시한다.
+    function watchSiteTheme() {
+        if (!window.MutationObserver) {
+            return;
+        }
+        new MutationObserver(function () {
+            for (var i = 0; i < editors.length; i++) {
+                applyTheme(editors[i]);
+            }
+        }).observe(document.documentElement, {attributes: true, attributeFilter: ['data-theme']});
+    }
+
     function getDocHeight() {
         var D = document;
         return Math.max(
@@ -75,7 +113,6 @@
             textarea = next(widget),
             editor = ace.edit(div),
             mode = widget.getAttribute('data-mode'),
-            theme = widget.getAttribute('data-theme'),
             wordwrap = widget.getAttribute('data-wordwrap'),
             toolbar = prev(widget),
             main_block = toolbar.parentNode;
@@ -96,9 +133,10 @@
         if (mode) {
             editor.getSession().setMode('ace/mode/' + mode);
         }
-        if (theme) {
-            editor.setTheme("ace/theme/" + theme);
-        }
+        var entry = {widget: widget, editor: editor};
+        editors.push(entry);
+        applyTheme(entry);
+
         if (wordwrap == "true") {
             editor.getSession().setUseWrapMode(true);
         }
@@ -172,6 +210,8 @@
 
             apply_widget(widget);
         }
+
+        watchSiteTheme();
     }
 
     if (window.addEventListener) { // W3C

--- a/site/django_ace/widgets.py
+++ b/site/django_ace/widgets.py
@@ -7,11 +7,21 @@ from django.forms.utils import flatatt
 from django.utils.safestring import mark_safe
 
 
+# 에디터 테마는 사이트 테마(라이트/다크)를 따라간다. 두 값 모두 마크업으로 내보내고
+# 최종 선택은 widget.js 가 <html data-theme> 를 보고 한다.
+# 서버에서 고르지 않는 이유는 '시스템 기본값(auto)' 때문이다. auto 는 브라우저의
+# prefers-color-scheme 으로만 판정되므로 서버가 알 수 없고, 서버에서 고르면
+# auto 사용자에게 항상 라이트 테마가 나가 버린다.
+DEFAULT_LIGHT_THEME = 'github'
+DEFAULT_DARK_THEME = 'twilight'
+
+
 class AceWidget(forms.Textarea):
     def __init__(self, mode=None, theme=None, wordwrap=False, width='100%', height='300px',
-                 no_ace_media=False, *args, **kwargs):
+                 no_ace_media=False, dark_theme=None, *args, **kwargs):
         self.mode = mode
-        self.theme = theme
+        self.theme = theme or DEFAULT_LIGHT_THEME
+        self.dark_theme = dark_theme or DEFAULT_DARK_THEME
         self.wordwrap = wordwrap
         self.width = width
         self.height = height
@@ -41,6 +51,8 @@ class AceWidget(forms.Textarea):
             ace_attrs['data-mode'] = self.mode
         if self.theme:
             ace_attrs['data-theme'] = self.theme
+        if self.dark_theme:
+            ace_attrs['data-theme-dark'] = self.dark_theme
         if self.wordwrap:
             ace_attrs['data-wordwrap'] = 'true'
 

--- a/site/judge/admin/contest.py
+++ b/site/judge/admin/contest.py
@@ -610,7 +610,7 @@ class ContestAdmin(VersionAdmin):
         if 'problem_label_script' in form.base_fields:
             # form.base_fields['problem_label_script'] does not exist when the user has only view permission
             # on the model.
-            form.base_fields['problem_label_script'].widget = AceWidget('lua', request.profile.ace_theme)
+            form.base_fields['problem_label_script'].widget = AceWidget('lua')
 
         #랜덤 접근코드 생성
         if obj == None:

--- a/site/judge/admin/profile.py
+++ b/site/judge/admin/profile.py
@@ -30,7 +30,6 @@ class ProfileForm(ModelForm):
         widgets = {
             'timezone': AdminSelect2Widget,
             'language': AdminSelect2Widget,
-            'ace_theme': AdminSelect2Widget,
             'site_theme': AdminSelect2Widget,
             'current_contest': AdminSelect2Widget,
             'about': AdminMartorWidget(attrs={'data-markdownfy-url': reverse_lazy('profile_preview')}),
@@ -181,7 +180,7 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
     # fields = ('user', 'display_rank', 'about', 'organizations', 'timezone', 'language', 'ace_theme',
     #           'math_engine', 'last_access', 'ip', 'mute', 'is_unlisted', 'is_banned_from_problem_voting',
     #           'username_display_override', 'notes', 'is_totp_enabled', 'user_script', 'current_contest')
-    fields = ('user', 'display_rank', 'about', 'timezone', 'language', 'ace_theme', 'department', 'school',
+    fields = ('user', 'display_rank', 'about', 'timezone', 'language', 'department', 'school',
               'student_number', 'math_engine', 'last_access', 'ip', 'mute', 'is_unlisted', 'is_banned_from_problem_voting',
               'username_display_override', 'notes', 'is_totp_enabled', 'user_script', 'current_contest')
     readonly_fields = ('user',)
@@ -309,5 +308,5 @@ class ProfileAdmin(NoBatchDeleteMixin, VersionAdmin):
         form = super(ProfileAdmin, self).get_form(request, obj, **kwargs)
         if 'user_script' in form.base_fields:
             # form.base_fields['user_script'] does not exist when the user has only view permission on the model.
-            form.base_fields['user_script'].widget = AceWidget('javascript', request.profile.ace_theme)
+            form.base_fields['user_script'].widget = AceWidget('javascript')
         return form

--- a/site/judge/admin/runtime.py
+++ b/site/judge/admin/runtime.py
@@ -49,7 +49,7 @@ class LanguageAdmin(VersionAdmin):
     def get_form(self, request, obj=None, **kwargs):
         form = super(LanguageAdmin, self).get_form(request, obj, **kwargs)
         if obj is not None:
-            form.base_fields['template'].widget = AceWidget(obj.ace, request.profile.ace_theme)
+            form.base_fields['template'].widget = AceWidget(obj.ace)
         return form
 
     def save_model(self, request, obj, form, change):

--- a/site/judge/admin/submission.py
+++ b/site/judge/admin/submission.py
@@ -197,8 +197,7 @@ class SubmissionSourceInline(admin.StackedInline):
     extra = 0
 
     def get_formset(self, request, obj=None, **kwargs):
-        kwargs.setdefault('widgets', {})['source'] = AceWidget(mode=obj and obj.language.ace,
-                                                               theme=request.profile.ace_theme)
+        kwargs.setdefault('widgets', {})['source'] = AceWidget(mode=obj and obj.language.ace)
         return super().get_formset(request, obj, **kwargs)
 
 from django import forms

--- a/site/judge/forms.py
+++ b/site/judge/forms.py
@@ -63,12 +63,11 @@ class ProfileForm(ModelForm):
     class Meta:
         model = Profile
         # fields = ['about', 'organizations', 'timezone', 'language', 'ace_theme', 'user_script']
-        fields = ['about', 'timezone', 'language', 'ace_theme', 'site_theme', 'user_script', 'department']
+        fields = ['about', 'timezone', 'language', 'site_theme', 'user_script', 'department']
         widgets = {
             'user_script': AceWidget(theme='github'),
             'timezone': Select2Widget(attrs={'style': 'width:200px'}),
             'language': Select2Widget(attrs={'style': 'width:200px'}),
-            'ace_theme': Select2Widget(attrs={'style': 'width:200px'}),
             'site_theme': Select2Widget(attrs={'style': 'width:200px'}),
             'department': Select2Widget(attrs={'style': 'width:200px'}),
         }
@@ -176,7 +175,7 @@ class DownloadDataForm(Form):
 
 
 class ProblemSubmitForm(ModelForm):
-    source = CharField(max_length=65536, widget=AceWidget(theme='twilight', no_ace_media=True))
+    source = CharField(max_length=65536, widget=AceWidget(no_ace_media=True))
     judge = ChoiceField(choices=(), widget=forms.HiddenInput(), required=False)
 
     def __init__(self, *args, judge_choices=(), **kwargs):

--- a/site/judge/views/problem.py
+++ b/site/judge/views/problem.py
@@ -1076,8 +1076,6 @@ class ProblemSubmit(LoginRequiredMixin, ProblemMixin, TitleMixin, SingleObjectFo
         form_data = getattr(form, 'cleaned_data', form.initial)
         if 'language' in form_data:
             form.fields['source'].widget.mode = form_data['language'].ace
-        form.fields['source'].widget.theme = self.request.profile.ace_theme
-
         return form
 
     def get_success_url(self):

--- a/site/templates/user/edit-profile.html
+++ b/site/templates/user/edit-profile.html
@@ -388,10 +388,6 @@
                         <label class="inline-header grayed">언어</label>
                         <span class="fullwidth">{{ form.language }}</span>
                     </div>
-                    <div class="ace-theme" style="margin-bottom: 15px;">
-                        <label class="inline-header grayed">편집기 테마</label>
-                        <span class="fullwidth">{{ form.ace_theme }}</span>
-                    </div>
                     <div class="site-theme" style="margin-bottom: 15px;">
                         <label class="inline-header grayed">사이트 테마</label>
                         <span class="fullwidth">{{ form.site_theme }}</span>
@@ -425,10 +421,6 @@
                             <tr class="time-zone" title="{{ _('Select your closest major city') }}">
                                 <td><label class="inline-header grayed">{{ _('Time zone:') }}</label></td>
                                 <td><span class="fullwidth">{{ form.timezone }}</span></td>
-                            </tr>
-                            <tr class="ace-theme">
-                                <td><label class="inline-header grayed">{{ _('Editor theme:') }}</label></td>
-                                <td><span class="fullwidth">{{ form.ace_theme }}</span></td>
                             </tr>
                             {% if has_math_config %}
                                 <tr class="math-engine">


### PR DESCRIPTION
## 문제
<img width="762" height="353" alt="image" src="https://github.com/user-attachments/assets/77b7849d-96cd-4989-b3e6-25702f99dff8" />

다크모드에서 문제 제출 페이지의 코드 에디터만 흰 배경으로 남아, 어두운 페이지
한가운데 흰 상자가 박히는 문제가 있었습니다. 에디터 자체는 정상 동작하며
색상만 어긋난 상태입니다.

## 원인

에디터 테마는 프로필의 `ace_theme` 값을 따르는데(`ProblemSubmitForm`이 선언한
`twilight`을 뷰가 프로필 값으로 덮어씀), 이 설정을 UI에서 바꿀 수 없는
상태였습니다.

`edit-profile.html`이 같은 `<form>` 안에서 `{{ form.ace_theme }}`를 두 번
렌더하고 있었습니다. 하나는 화면에 보이는 드롭다운, 다른 하나는 `display: none`
처리된 "사용 X" 블록 안입니다. `display: none`은 폼 제출을 막지 않으므로
브라우저가 두 값을 모두 전송하고, Django의 `QueryDict`는 마지막 값을 취합니다.

## 변경 내용

### 1. 에디터 테마를 사이트 테마에 연동

`AceWidget`이 라이트/다크 두 테마를 모두 마크업으로 내보내고, 최종 선택은
`widget.js`가 `<html data-theme>`를 보고 합니다.

- 라이트: `github` (기존 기본값과 동일 — 라이트 사용자에게 변화 없음)
- 다크: `twilight` (`ProblemSubmitForm`이 원래 선언해 두었던 값)

-  서버에서 고르지 않은 이유는 사이트 테마의 '시스템 기본값(auto)' 때문입니다.
-  auto는 브라우저의 `prefers-color-scheme`으로만 판정되므로 서버는 알 수 없고, 서버에서 정하면 auto 사용자에게 항상 라이트 테마가 나가게 됩니다.
- 클라이언트에서 판정하면 light / dark / auto 세 경우가 모두 자동으로 맞습니다.

`MutationObserver`로 `data-theme` 변화를 감시해, auto 사용자가 OS 테마를 바꿨을
때 새로고침 없이 에디터 테마도 따라가도록 했습니다.

### 2. 프로필 값을 읽던 5곳 정리

문제 제출 페이지 외에 관리자 화면 4곳(사용자 스크립트 / 언어 템플릿 / 제출 소스
/ 대회 라벨 스크립트)도 같은 방식을 쓰고 있어 함께 정리했습니다. 한 곳만
고치면 관리자 화면은 계속 어긋난 채로 남습니다.

### 3. 동작하지 않던 "편집기 테마" 설정 제거

- 프로필 수정 페이지의 드롭다운과 숨겨진 중복 렌더 모두 제거
- `ProfileForm`과 Django 관리자 폼에서 `ace_theme` 필드 제외
  (폼 필드로 남겨두면 POST로 조작 가능하므로)
- **DB 필드(`Profile.ace_theme`)는 유지** - 마이그레이션 불필요하고, 추후 사용자 선택 되살릴 여지를 남깁니다.

## 배포 시 고려해야할 것 (필수)
<venv>/bin/python manage.py collectstatic --noinput
sudo supervisorctl restart site

## 결과
<img width="715" height="422" alt="image" src="https://github.com/user-attachments/assets/e600452d-521a-46e2-9a83-1922e64ae830" />

<img width="736" height="481" alt="image" src="https://github.com/user-attachments/assets/2f5cacd5-59a7-4148-b72c-4e6c82087875" />

- 편집기 테마 드롭다운 삭제

<img width="614" height="458" alt="image" src="https://github.com/user-attachments/assets/3240d25e-a2d6-4f40-a209-170e91a063fe" />


- 기존
