### PR TITLE
fix: 문제 개요의 해설탭 삭제

### DIFF
--- a/site/judge/views/contests.py
+++ b/site/judge/views/contests.py
@@ -887,14 +887,7 @@ class ContestDetail(ContestMixin, TitleMixin, ContestAutoJoinMixin, CommentedDet
         ).exists()
 
         contest_problems = Problem.objects.filter(contests__contest=self.object) \
-            .order_by('contests__order').defer('description') \
-            .annotate(
-                has_public_editorial=Case(
-                    When(solution__is_public=True, solution__publish_on__lte=timezone.now(), then=True),
-                    default=False,
-                    output_field=BooleanField(),
-                )
-            )
+            .order_by('contests__order').defer('description')
 
         problem_stats = (
             Submission.objects.filter(contest_object_id=self.object.id)
@@ -931,11 +924,7 @@ class ContestDetail(ContestMixin, TitleMixin, ContestAutoJoinMixin, CommentedDet
 
         context['contest_problems'] = contest_problems
 
-        context['metadata'] = {
-            'has_public_editorials': any(
-                problem.is_public and problem.has_public_editorial for problem in contest_problems
-            ),
-        }
+        context['metadata'] = {}
         context['metadata'].update(
             **self.object.contest_problems
             .annotate(

--- a/site/templates/contest/contest.html
+++ b/site/templates/contest/contest.html
@@ -412,9 +412,6 @@
                             <th class="points">{{ _('Points') }}</th>
                             <th class="ac-rate">{{ _('AC Rate') }}</th>
                             <th class="users">맞힌 사람</th>
-                            {% if metadata.has_public_editorials %}
-                                <th>{{ _('Editorials') }}</th>
-                            {% endif %}
                         </tr>
                         </thead>
                         <tbody>
@@ -464,13 +461,6 @@
                                 <td class="points">{{ problem.points|floatformat }}</td>
                                 <td class="ac-rate">{{ problem.correct_rate|floatformat(2) }}%</td>
                                 <td lass="users">{{ problem.correct_users }}</td>
-                                {% if metadata.has_public_editorials %}
-                                    <td>
-                                        {% if problem.is_public and problem.has_public_editorial %}
-                                            <a href="{{ url('problem_editorial', problem.code) }}">{{ _('Editorial') }}</a>
-                                        {% endif %}
-                                    </td>
-                                {% endif %}
                             </tr>
                         {% endfor %}
                         </tbody>


### PR DESCRIPTION
<img width="2210" height="1470" alt="image" src="https://github.com/user-attachments/assets/bed6b125-df14-4b72-9999-f43013d7d900" />

기존 : 해설이 있는 문제에 한해 개요에서 해설 바로가기 탭 생성

<img width="2710" height="1408" alt="image" src="https://github.com/user-attachments/assets/0b3ec55b-e944-4cd9-93b1-8faef9bde51b" />

수정 : 개요에서 해설 바로가기 탭 삭제 

해설 탭 삭제 제외 다른 부분에 영향이 가지 않음을 확인하였습니다. 
