### PR TITLE
fix: 내 제출 목록에서 문제 필터 검색이 되지 않던 문제 해결

### DIFF
--- a/site/judge/views/submission.py
+++ b/site/judge/views/submission.py
@@ -500,6 +500,17 @@ class AllUserSubmissions(ConditionalUserTabMixin, UserMixin, SubmissionsListBase
         if self.request.user.is_authenticated:
             return reverse('all_user_submissions', kwargs={'user': self.request.user.username})
 
+    def get_searchable_problems(self):
+        # 이 페이지는 특정 유저의 제출만 보이므로, 문제 필터도 목록에 실제로
+        # 등장하는 문제(해당 유저가 제출한 문제 중 보이는 문제)로 한정한다.
+        if not self.request.user or not self.request.user.is_authenticated:
+            return Problem.objects.none().values_list('code', 'name')
+        if self.request.user.is_superuser or self.request.user.is_staff:
+            base = Problem.objects.all()
+        else:
+            base = Problem.get_visible_problems(self.request.user)
+        return base.filter(submission__user=self.profile).distinct().values_list('code', 'name')
+
     def get_context_data(self, **kwargs):
         context = super(AllUserSubmissions, self).get_context_data(**kwargs)
         context['dynamic_update'] = context['page_obj'].number == 1


### PR DESCRIPTION
## fix: 내 제출 목록에서 문제 필터 검색이 되지 않던 문제 해결

### 문제 상황
- 대회/과제의 제출 확인 페이지에서는 필터의 문제 검색이 정상 동작함
- 그러나 **내 프로필 → 제출 목록** 플로우에서는 문제 필터 드롭다운이 항상 비어 있어 검색 자체가 불가능함
<img width="951" height="331" alt="image" src="https://github.com/user-attachments/assets/0c7d1639-71a0-4e36-928c-77a5bc88c1ff" />


### 원인
- `SubmissionsListBase.get_searchable_problems()`는 학생(비 staff) 계정에 대해
  `in_contest`일 때만 대회 문제를 반환하고, 그 외에는 `Problem.objects.none()`을 반환함
- 프로필의 제출 목록 뷰인 `AllUserSubmissions`는 `in_contest = False`로 고정되어 있어,
  학생은 항상 빈 목록 분기를 타게 되어 드롭다운에 선택지가 생성되지 않음
- 문제 필터 드롭다운은 AJAX가 아니라 서버가 렌더링한 `<option>` 목록을 검색하는
  정적 select2이므로, 서버 반환 목록이 비면 검색이 불가능함

### 해결 방법
- `AllUserSubmissions`에 `get_searchable_problems()` 오버라이드 추가 (베이스 클래스는 변경 없음)
- 드롭다운 목록을 **해당 유저가 제출한 문제 ∩ 열람 가능한 문제**로 한정
  - 학생: `Problem.get_visible_problems(user)` 기준 — 목록 렌더링 시 사용되는
    `filter_submissions_by_visible_problems()`와 동일한 가시성 규칙이므로,
    목록에 실제로 보이는 제출의 문제와 드롭다운이 정확히 일치함
  - 교수/관리자: 해당 유저가 제출한 전체 문제
- 전체 공개 문제를 노출하지 않고 제출 이력이 있는 문제만 노출하므로,
  드롭다운과 실제 목록 내용이 항상 일치함
<img width="942" height="390" alt="image" src="https://github.com/user-attachments/assets/6d45a843-5aea-4f00-a132-16552b2bddc6" />
<img width="947" height="331" alt="image" src="https://github.com/user-attachments/assets/7905232b-e201-44c3-9256-a1451025dc35" />

  
  ### 변경 파일
- `site/judge/views/submission.py` — `AllUserSubmissions.get_searchable_problems()` 오버라이드 추가